### PR TITLE
chore: update linter to v1.31.0

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
   - master
 
 variables:
-  GO_VERSION: 1.14
+  GO_VERSION: 1.15
   GOPATH: $(Agent.BuildDirectory)/go
 
 jobs:

--- a/cmd/kms-rest/startcmd/start.go
+++ b/cmd/kms-rest/startcmd/start.go
@@ -489,7 +489,6 @@ func prepareNewMasterKey(masterKeyStore ariesstorage.Store, secLock secretlock.S
 	masterKeyEnc, err := secLock.Encrypt(keyURI, &secretlock.EncryptRequest{
 		Plaintext: string(masterKeyContent),
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -10,12 +10,13 @@ set -e
 echo "Running $0"
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
-GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.27.0"
+GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.31.0"
 
 
 if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-#${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run
+#${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run TODO: https://github.com/trustbloc/hub-kms/issues/58
 ${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/kms-rest ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/test/bdd ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -32,9 +32,6 @@ const (
 	couchDBComposeFilePath = "./fixtures/couchdb"
 )
 
-var composition []*dockerutil.Composition
-var composeFiles = []string{couchDBComposeFilePath, kmsRestComposeFilePath}
-
 // Feature of the system under test.
 type feature interface {
 	// SetContext is called before every scenario is run with a fresh new context
@@ -81,6 +78,10 @@ func runBDDTests(tags, format string) int {
 }
 
 func initializeTestSuite(ctx *godog.TestSuiteContext) {
+	composeFiles := []string{couchDBComposeFilePath, kmsRestComposeFilePath}
+
+	var composition []*dockerutil.Composition
+
 	ctx.BeforeSuite(func() {
 		if os.Getenv("DISABLE_COMPOSITION") == "true" {
 			return
@@ -171,6 +172,7 @@ func getCmdArg(argName string) string {
 // generateUUID returns a UUID based on RFC 4122.
 func generateUUID() string {
 	id := dockerutil.GenerateBytesUUID()
+
 	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:])
 }
 

--- a/test/bdd/dockerutil/compose.go
+++ b/test/bdd/dockerutil/compose.go
@@ -87,7 +87,8 @@ func (c *Composition) refreshContainerList() (err error) {
 	if thisProjectsContainers, err = c.DockerClient.ListContainers(
 		docker.ListContainersOptions{
 			All:     true,
-			Filters: map[string][]string{"name": {c.ProjectName}}}); err != nil {
+			Filters: map[string][]string{"name": {c.ProjectName}},
+		}); err != nil {
 		return fmt.Errorf("error refreshing container list for project '%s':  %s", c.ProjectName, err)
 	}
 
@@ -152,7 +153,7 @@ func (c *Composition) GenerateLogs(dir, logName string) error {
 		return err
 	}
 
-	f, err := os.OpenFile(logName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(logName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) //nolint: gosec
 	if err != nil {
 		return err
 	}

--- a/test/bdd/pkg/bddutil/bddutil.go
+++ b/test/bdd/pkg/bddutil/bddutil.go
@@ -7,14 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package bddutil
 
 import (
+	"context"
 	"crypto/tls"
 	"io"
 	"net/http"
+
+	"github.com/trustbloc/edge-core/pkg/log"
 )
+
+var logger = log.New("kms-rest-bdd-tests")
 
 // HTTPDo makes an HTTP request.
 func HTTPDo(method, url, contentType string, body io.Reader, tlsConfig *tls.Config) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(context.Background(), method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +30,17 @@ func HTTPDo(method, url, contentType string, body io.Reader, tlsConfig *tls.Conf
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig}}
+			TLSClientConfig: tlsConfig,
+		},
+	}
 
 	return httpClient.Do(req)
+}
+
+// CloseResponseBody closes the response body.
+func CloseResponseBody(respBody io.Closer) {
+	err := respBody.Close()
+	if err != nil {
+		logger.Errorf("Failed to close response body: %s", err.Error())
+	}
 }

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -25,7 +25,7 @@ func NewBDDContext(caCertPath string) (*BDDContext, error) {
 		return nil, err
 	}
 
-	return &BDDContext{tlsConfig: &tls.Config{RootCAs: rootCAs}}, nil
+	return &BDDContext{tlsConfig: &tls.Config{RootCAs: rootCAs}}, nil //nolint: gosec
 }
 
 // TLSConfig returns a TLS config that BDD context was initialized with.

--- a/test/bdd/pkg/healthcheck/healthcheck_steps.go
+++ b/test/bdd/pkg/healthcheck/healthcheck_steps.go
@@ -71,6 +71,7 @@ func (s *Steps) validateResponse(expected string) error {
 	var healthCheckResp struct {
 		Status string `json:"status"`
 	}
+
 	if err := json.Unmarshal(s.response, &healthCheckResp); err != nil {
 		return err
 	}

--- a/test/bdd/pkg/keystore/keystore_steps.go
+++ b/test/bdd/pkg/keystore/keystore_steps.go
@@ -53,12 +53,13 @@ func (s *Steps) RegisterSteps(ctx *godog.ScenarioContext) {
 
 func (s *Steps) sendCreateKeystoreReq(endpoint string) error {
 	body := bytes.NewBuffer([]byte(createKeystoreReq))
-	resp, err := bddutil.HTTPDo(http.MethodPost, endpoint, contentType, body, s.bddContext.TLSConfig())
+
+	resp, err := bddutil.HTTPDo(http.MethodPost, endpoint, contentType, body, s.bddContext.TLSConfig()) //nolint: bodyclose
 	if err != nil {
 		return err
 	}
 
-	defer resp.Body.Close()
+	defer bddutil.CloseResponseBody(resp.Body)
 
 	s.responseStatus = resp.StatusCode
 	s.responseLocation = resp.Header.Get(locationHeader)


### PR DESCRIPTION
* updated linter to version 1.31.0 and fixed found warnings;
* fixed Go version on pipeline;
* added linter for bdd tests;

Linter for `pkg` is going to be handled by #58.

Closes #57

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>