### PR TITLE
refactor: improve naming for components and dependencies

### DIFF
--- a/cmd/kms-rest/go.mod
+++ b/cmd/kms-rest/go.mod
@@ -8,12 +8,12 @@ go 1.15
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 )

--- a/cmd/kms-rest/go.sum
+++ b/cmd/kms-rest/go.sum
@@ -515,8 +515,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9/go.mod h1:cLWhBbjgrA04Di9ufGqAuTCdoM33Xq4Cuc3fL/VLAgI=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201028195746-556cee009e20/go.mod h1:UF34fHG3WLB1QSxeIqDrWDhK98GLqA09NauwultnG7w=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c h1:kMOoCmU+Ir5ZuV9HU1/Smma9TcuDGGxGJ6fY6q2/fDA=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587 h1:/G0Cwa24V9sMrqD4LFZNDOU+41Of/kr7wpNq/v76hI8=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5 h1:lcnsNy983eXWEhi3uWFq/RV4ut6umrMQj/V7FtZ175A=
@@ -842,8 +842,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/kms-rest/startcmd/start_test.go
+++ b/cmd/kms-rest/startcmd/start_test.go
@@ -74,7 +74,7 @@ func TestStartCmdWithBlankArg(t *testing.T) {
 		tlsServeCertPathFlagName, tlsServeKeyPathFlagName,
 		databaseTypeFlagName, databaseURLFlagName, databasePrefixFlagName,
 		kmsDatabaseTypeFlagName, kmsDatabaseURLFlagName, kmsDatabasePrefixFlagName, kmsMasterKeyPathFlagName,
-		operationalKMSStorageTypeFlagName, operationalKMSStorageURLFlagName, operationalKMSStoragePrefixFlagName,
+		keyManagerStorageTypeFlagName, keyManagerStorageURLFlagName, keyManagerStoragePrefixFlagName,
 	}
 
 	t.Parallel()
@@ -101,7 +101,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		args := []string{
 			"--" + databaseTypeFlagName, storageTypeMemOption,
 			"--" + kmsDatabaseTypeFlagName, storageTypeMemOption,
-			"--" + operationalKMSStorageTypeFlagName, storageTypeMemOption,
+			"--" + keyManagerStorageTypeFlagName, storageTypeMemOption,
 		}
 		startCmd.SetArgs(args)
 
@@ -119,7 +119,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		args := []string{
 			"--" + hostURLFlagName, "hostname",
 			"--" + kmsDatabaseTypeFlagName, storageTypeMemOption,
-			"--" + operationalKMSStorageTypeFlagName, storageTypeMemOption,
+			"--" + keyManagerStorageTypeFlagName, storageTypeMemOption,
 		}
 		startCmd.SetArgs(args)
 
@@ -136,7 +136,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		args := []string{
 			"--" + hostURLFlagName, "hostname",
 			"--" + databaseTypeFlagName, storageTypeMemOption,
-			"--" + operationalKMSStorageTypeFlagName, storageTypeMemOption,
+			"--" + keyManagerStorageTypeFlagName, storageTypeMemOption,
 		}
 		startCmd.SetArgs(args)
 
@@ -148,7 +148,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			err.Error())
 	})
 
-	t.Run("test missing operational-kms-storage-type arg", func(t *testing.T) {
+	t.Run("test missing key-manager-storage-type arg", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
 		args := []string{
@@ -161,8 +161,8 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		err := startCmd.Execute()
 
 		require.Error(t, err)
-		require.Equal(t, "Neither operational-kms-storage-type (command line flag) nor "+
-			"KMS_OPERATIONAL_KMS_STORAGE_TYPE (environment variable) have been set.",
+		require.Equal(t, "Neither key-manager-storage-type (command line flag) nor "+
+			"KMS_KEY_MANAGER_STORAGE_TYPE (environment variable) have been set.",
 			err.Error())
 	})
 }
@@ -314,9 +314,9 @@ func TestStartKMSService(t *testing.T) {
 func TestPrepareOperationConfig(t *testing.T) {
 	t.Run("Success with in-memory db option", func(t *testing.T) {
 		config, err := prepareOperationConfig(&kmsRestParameters{
-			storageParams:               &storageParameters{storageType: storageTypeMemOption},
-			kmsStorageParams:            &storageParameters{storageType: storageTypeMemOption},
-			operationalKMSStorageParams: &storageParameters{storageType: storageTypeMemOption},
+			storageParams:           &storageParameters{storageType: storageTypeMemOption},
+			kmsStorageParams:        &storageParameters{storageType: storageTypeMemOption},
+			keyManagerStorageParams: &storageParameters{storageType: storageTypeMemOption},
 		})
 
 		require.NoError(t, err)
@@ -329,9 +329,9 @@ func TestPrepareOperationConfig(t *testing.T) {
 	// TODO(#53): don't depend on error message defined in external package
 	t.Run("Fail with CouchDB option", func(t *testing.T) {
 		config, err := prepareOperationConfig(&kmsRestParameters{
-			storageParams:               &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
-			kmsStorageParams:            &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
-			operationalKMSStorageParams: &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
+			storageParams:           &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
+			kmsStorageParams:        &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
+			keyManagerStorageParams: &storageParameters{storageType: storageTypeCouchDBOption, storageURL: "url"},
 		})
 
 		require.Error(t, err)
@@ -341,9 +341,9 @@ func TestPrepareOperationConfig(t *testing.T) {
 
 	t.Run("Fail with invalid db option", func(t *testing.T) {
 		config, err := prepareOperationConfig(&kmsRestParameters{
-			storageParams:               &storageParameters{storageType: "invalid"},
-			kmsStorageParams:            &storageParameters{storageType: storageTypeMemOption},
-			operationalKMSStorageParams: &storageParameters{storageType: storageTypeMemOption},
+			storageParams:           &storageParameters{storageType: "invalid"},
+			kmsStorageParams:        &storageParameters{storageType: storageTypeMemOption},
+			keyManagerStorageParams: &storageParameters{storageType: storageTypeMemOption},
 		})
 
 		require.Nil(t, config)
@@ -351,11 +351,11 @@ func TestPrepareOperationConfig(t *testing.T) {
 	})
 }
 
-func TestOperationalKMSStorageResolver(t *testing.T) { // TODO(#53): Rewrite this test
+func TestKeyManagerStorageResolver(t *testing.T) { // TODO(#53): Rewrite this test
 	config, err := prepareOperationConfig(&kmsRestParameters{
-		storageParams:               &storageParameters{storageType: storageTypeMemOption},
-		kmsStorageParams:            &storageParameters{storageType: storageTypeMemOption},
-		operationalKMSStorageParams: &storageParameters{storageType: storageTypeSDSOption},
+		storageParams:           &storageParameters{storageType: storageTypeMemOption},
+		kmsStorageParams:        &storageParameters{storageType: storageTypeMemOption},
+		keyManagerStorageParams: &storageParameters{storageType: storageTypeEDVOption},
 	})
 
 	require.NotNil(t, config)
@@ -395,7 +395,7 @@ func requiredArgs() []string {
 		"--" + hostURLFlagName, "localhost:8080",
 		"--" + databaseTypeFlagName, storageTypeMemOption,
 		"--" + kmsDatabaseTypeFlagName, storageTypeMemOption,
-		"--" + operationalKMSStorageTypeFlagName, storageTypeMemOption,
+		"--" + keyManagerStorageTypeFlagName, storageTypeMemOption,
 	}
 }
 
@@ -409,7 +409,7 @@ func setEnvVars(t *testing.T) {
 	err = os.Setenv(kmsDatabaseTypeEnvKey, storageTypeMemOption)
 	require.NoError(t, err)
 
-	err = os.Setenv(operationalKMSStorageTypeEnvKey, storageTypeMemOption)
+	err = os.Setenv(keyManagerStorageTypeEnvKey, storageTypeMemOption)
 	require.NoError(t, err)
 }
 
@@ -423,7 +423,7 @@ func unsetEnvVars(t *testing.T) {
 	err = os.Unsetenv(kmsDatabaseTypeEnvKey)
 	require.NoError(t, err)
 
-	err = os.Unsetenv(operationalKMSStorageTypeEnvKey)
+	err = os.Unsetenv(keyManagerStorageTypeEnvKey)
 	require.NoError(t, err)
 }
 

--- a/docs/kms_rest_cli.md
+++ b/docs/kms_rest_cli.md
@@ -29,9 +29,11 @@ Parameters can be set by command line arguments or environment variables:
     --kms-secrets-database-url string         The URL of the database for KMS secrets. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_SECRETS_DATABASE_URL
     --kms-secrets-database-prefix string      An optional prefix to be used when creating and retrieving the underlying KMS secrets database. Alternatively, this can be set with the following environment variable: KMS_SECRETS_DATABASE_PREFIX
 
-    --operational-kms-storage-type string     The type of storage to use for Operational (user-specific) KMS. Supported options: mem, couchdb, sds. Alternatively, this can be set with the following environment variable: KMS_OPERATIONAL_KMS_STORAGE_TYPE
-    --operational-kms-storage-url string      The URL of storage for Operational KMS. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_OPERATIONAL_KMS_STORAGE_URL
-    --operational-kms-storage-prefix string   An optional prefix to be used when creating and retrieving the underlying Operational KMS storage. Alternatively, this can be set with the following environment variable: KMS_OPERATIONAL_KMS_STORAGE_PREFIX
+    --kms-secrets-master-key-path string      The path to the file with master key to be used for secret lock. If missing noop service lock is used. Alternatively, this can be set with the following environment variable: KMS_SECRETS_MASTER_KEY_PATH
+
+    --key-manager-storage-type string         The type of storage to use for user's key manager. Supported options: mem, couchdb, edv. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_TYPE
+    --key-manager-storage-url string          The URL of storage for user's key manager. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_URL
+    --key-manager-storage-prefix string       An optional prefix to be used when creating and retrieving the underlying user's key manager storage. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_PREFIX
 ```
 
 ## Example
@@ -41,5 +43,5 @@ $ cd cmd/kms-rest
 $ go build
 $ ./kms-rest start --host-url localhost:8076 --database-type couchdb --database-url admin:password@couchdb.example.com:5984 --database-prefix keystore \
 --kms-secrets-database-type couchdb --kms-secrets-database-url admin:password@couchdb.example.com:5984 --kms-secrets-database-prefix kms \
---operational-kms-storage-type couchdb --operational-kms-storage-url admin:password@couchdb.example.com:5984 --operational-kms-storage-prefix opkms
+--key-manager-storage-type couchdb --key-manager-storage-url admin:password@couchdb.example.com:5984 --key-manager-storage-prefix kms_user
 ```

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,11 @@ go 1.15
 require (
 	github.com/google/tink/go v1.5.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/rs/xid v1.2.1
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
 )
 
 replace github.com/kilic/bls12-381 => github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c h1:kMOoCmU+Ir5ZuV9HU1/Smma9TcuDGGxGJ6fY6q2/fDA=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
@@ -780,8 +780,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -15,26 +15,26 @@ import (
 
 // Keystore represents user's keystore with a list of associated keys and metadata.
 type Keystore struct {
-	ID                       string          `json:"id"`
-	Controller               string          `json:"controller"`
-	DelegateKeyID            string          `json:"delegateKeyID,omitempty"`
-	RecipientKeyID           string          `json:"recipientKeyID,omitempty"`
-	MACKeyID                 string          `json:"macKeyID,omitempty"`
-	OperationalVaultID       string          `json:"operationalVaultID,omitempty"`
-	OperationalEDVCapability json.RawMessage `json:"operationalEDVCapability,omitempty"`
-	OperationalKeyIDs        []string        `json:"operationalKeyIDs,omitempty"`
-	CreatedAt                *time.Time      `json:"createdAt"`
+	ID             string          `json:"id"`
+	Controller     string          `json:"controller"`
+	DelegateKeyID  string          `json:"delegateKeyID,omitempty"`
+	RecipientKeyID string          `json:"recipientKeyID,omitempty"`
+	MACKeyID       string          `json:"macKeyID,omitempty"`
+	VaultID        string          `json:"vaultID,omitempty"`
+	EDVCapability  json.RawMessage `json:"edvCapability,omitempty"`
+	KeyIDs         []string        `json:"keyIDs,omitempty"`
+	CreatedAt      *time.Time      `json:"createdAt"`
 }
 
 // Options configures Keystore during creation.
 type Options struct {
-	ID                 string
-	Controller         string
-	DelegateKeyType    kms.KeyType
-	RecipientKeyType   kms.KeyType
-	MACKeyType         kms.KeyType
-	OperationalVaultID string
-	CreatedAt          *time.Time
+	ID               string
+	Controller       string
+	DelegateKeyType  kms.KeyType
+	RecipientKeyType kms.KeyType
+	MACKeyType       kms.KeyType
+	VaultID          string
+	CreatedAt        *time.Time
 }
 
 // Option configures Options.
@@ -78,10 +78,10 @@ func WithMACKeyType(k kms.KeyType) Option {
 	}
 }
 
-// WithOperationalVaultID sets the ID of the vault on SDS server for storing operational keys.
-func WithOperationalVaultID(id string) Option {
+// WithVaultID sets the ID of the vault on EDV server for storing keys.
+func WithVaultID(id string) Option {
 	return func(o *Options) {
-		o.OperationalVaultID = id
+		o.VaultID = id
 	}
 }
 

--- a/pkg/keystore/service.go
+++ b/pkg/keystore/service.go
@@ -71,10 +71,10 @@ func (s *service) Create(options ...Option) (*Keystore, error) {
 	}
 
 	k := &Keystore{
-		ID:                 opts.ID,
-		Controller:         opts.Controller,
-		OperationalVaultID: opts.OperationalVaultID,
-		CreatedAt:          opts.CreatedAt,
+		ID:         opts.ID,
+		Controller: opts.Controller,
+		VaultID:    opts.VaultID,
+		CreatedAt:  opts.CreatedAt,
 	}
 
 	if opts.DelegateKeyType != "" {

--- a/pkg/keystore/service_test.go
+++ b/pkg/keystore/service_test.go
@@ -95,7 +95,7 @@ func TestCreate(t *testing.T) {
 			keystore.WithDelegateKeyType(testKeyType),
 			keystore.WithRecipientKeyType(testKeyType),
 			keystore.WithMACKeyType(testKeyType),
-			keystore.WithOperationalVaultID(testVaultID),
+			keystore.WithVaultID(testVaultID),
 			keystore.WithCreatedAt(&createdAt),
 		}
 
@@ -264,12 +264,12 @@ func testKeystore() keystore.Keystore {
 	createdAt := time.Now().UTC()
 
 	return keystore.Keystore{
-		ID:                testKeystoreID,
-		Controller:        testController,
-		DelegateKeyID:     testKeyID,
-		RecipientKeyID:    testKeyID,
-		CreatedAt:         &createdAt,
-		OperationalKeyIDs: []string{testKeyID},
+		ID:             testKeystoreID,
+		Controller:     testController,
+		DelegateKeyID:  testKeyID,
+		RecipientKeyID: testKeyID,
+		CreatedAt:      &createdAt,
+		KeyIDs:         []string{testKeyID},
 	}
 }
 

--- a/pkg/kms/creator.go
+++ b/pkg/kms/creator.go
@@ -31,9 +31,9 @@ type ServiceCreator func(req *http.Request) (Service, error)
 
 // Config defines configuration for ServiceCreator.
 type Config struct {
-	KeystoreService               keystore.Service
-	CryptoService                 crypto.Crypto
-	OperationalKMSStorageResolver func(keystoreID string) (storage.Provider, error)
+	KeystoreService           keystore.Service
+	CryptoService             crypto.Crypto
+	KeyManagerStorageResolver func(keystoreID string) (storage.Provider, error)
 }
 
 // NewServiceCreator returns func to create KMS Service backed by LocalKMS and passphrase-based secret lock.
@@ -51,7 +51,7 @@ func NewServiceCreator(c *Config) ServiceCreator {
 			return nil, err
 		}
 
-		kmsStorageProvider, err := c.OperationalKMSStorageResolver(keystoreID)
+		kmsStorageProvider, err := c.KeyManagerStorageResolver(keystoreID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kms/service.go
+++ b/pkg/kms/service.go
@@ -53,7 +53,7 @@ func NewService(provider Provider) Service {
 	}
 }
 
-// CreateKey creates a new operational key and associates it with Keystore.
+// CreateKey creates a new key and associates it with Keystore.
 func (s *service) CreateKey(keystoreID string, kt kms.KeyType) (string, error) {
 	keyID, _, err := s.keyManager.Create(kt)
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *service) CreateKey(keystoreID string, kt kms.KeyType) (string, error) {
 		return "", NewServiceError(getKeystoreFailed, err)
 	}
 
-	k.OperationalKeyIDs = append(k.OperationalKeyIDs, keyID)
+	k.KeyIDs = append(k.KeyIDs, keyID)
 
 	err = s.keystore.Save(k)
 	if err != nil {
@@ -260,13 +260,13 @@ func (s *service) checkKey(keystoreID, keyID string) error {
 		return NewServiceError(getKeystoreFailed, err)
 	}
 
-	if len(k.OperationalKeyIDs) == 0 {
+	if len(k.KeyIDs) == 0 {
 		return NewServiceError(noKeysFailure, nil)
 	}
 
 	found := false
 
-	for _, id := range k.OperationalKeyIDs {
+	for _, id := range k.KeyIDs {
 		if id == keyID {
 			found = true
 

--- a/pkg/kms/service_test.go
+++ b/pkg/kms/service_test.go
@@ -59,7 +59,7 @@ func TestCreateKey(t *testing.T) {
 		require.Equal(t, testKeyID, keyID)
 		require.NoError(t, err)
 
-		require.Contains(t, k.OperationalKeyIDs, keyID)
+		require.Contains(t, k.KeyIDs, keyID)
 	})
 
 	t.Run("Error: key create", func(t *testing.T) {
@@ -117,8 +117,8 @@ func TestExportKey(t *testing.T) {
 		provider.MockKeyManager.ExportPubKeyBytesValue = []byte("public key bytes")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -167,8 +167,8 @@ func TestExportKey(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -187,8 +187,8 @@ func TestExportKey(t *testing.T) {
 		provider.MockKeyManager.ExportPubKeyBytesErr = errors.New("export error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -209,8 +209,8 @@ func TestSign(t *testing.T) {
 		provider.MockCrypto.SignValue = []byte("signature")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -259,8 +259,8 @@ func TestSign(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -279,8 +279,8 @@ func TestSign(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -299,8 +299,8 @@ func TestSign(t *testing.T) {
 		provider.MockCrypto.SignErr = errors.New("sign error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -324,8 +324,8 @@ func TestVerify(t *testing.T) {
 		provider.MockKeyManager.GetKeyValue = kh
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -368,8 +368,8 @@ func TestVerify(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -386,8 +386,8 @@ func TestVerify(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -407,8 +407,8 @@ func TestVerify(t *testing.T) {
 		provider.MockKeyManager.GetKeyValue = badKH
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -424,8 +424,8 @@ func TestVerify(t *testing.T) {
 		provider.MockCrypto.VerifyErr = errors.New("verify msg: invalid signature")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -446,8 +446,8 @@ func TestVerify(t *testing.T) {
 		provider.MockCrypto.VerifyErr = errors.New("other verify error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -470,8 +470,8 @@ func TestEncrypt(t *testing.T) {
 		provider.MockCrypto.EncryptNonceValue = []byte("nonce")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -522,8 +522,8 @@ func TestEncrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -543,8 +543,8 @@ func TestEncrypt(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -564,8 +564,8 @@ func TestEncrypt(t *testing.T) {
 		provider.MockCrypto.EncryptErr = errors.New("encrypt error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -587,8 +587,8 @@ func TestDecrypt(t *testing.T) {
 		provider.MockCrypto.DecryptValue = []byte("plain text")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -637,8 +637,8 @@ func TestDecrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -657,8 +657,8 @@ func TestDecrypt(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -677,8 +677,8 @@ func TestDecrypt(t *testing.T) {
 		provider.MockCrypto.DecryptErr = errors.New("decrypt error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -699,8 +699,8 @@ func TestComputeMAC(t *testing.T) {
 		provider.MockCrypto.ComputeMACValue = []byte("mac value")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -749,8 +749,8 @@ func TestComputeMAC(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -769,8 +769,8 @@ func TestComputeMAC(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -789,8 +789,8 @@ func TestComputeMAC(t *testing.T) {
 		provider.MockCrypto.ComputeMACErr = errors.New("compute MAC error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -810,8 +810,8 @@ func TestVerifyMAC(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -858,8 +858,8 @@ func TestVerifyMAC(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -876,8 +876,8 @@ func TestVerifyMAC(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -893,8 +893,8 @@ func TestVerifyMAC(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -950,8 +950,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1005,8 +1005,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1026,8 +1026,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1047,8 +1047,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		provider.MockCrypto.WrapError = errors.New("wrap error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1069,8 +1069,8 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1121,8 +1121,8 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1141,8 +1141,8 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		provider.MockKeyManager.GetKeyErr = errors.New("get key error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1161,8 +1161,8 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		provider.MockCrypto.UnwrapError = errors.New("unwrap error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1182,8 +1182,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1208,8 +1208,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		provider := mockkms.NewMockProvider()
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 
@@ -1227,8 +1227,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		provider.MockCrypto.UnwrapError = errors.New("unwrap error")
 
 		k := &keystore.Keystore{
-			ID:                testKeystoreID,
-			OperationalKeyIDs: []string{testKeyID},
+			ID:     testKeystoreID,
+			KeyIDs: []string{testKeyID},
 		}
 		provider.MockKeystoreService.GetKeystoreValue = k
 

--- a/pkg/restapi/kms/controller_test.go
+++ b/pkg/restapi/kms/controller_test.go
@@ -39,6 +39,6 @@ func newConfig() *operation.Config {
 		KeystoreService:   mockkeystore.NewMockService(),
 		KMSServiceCreator: func(_ *http.Request) (kmsservice.Service, error) { return mockkms.NewMockService(), nil },
 		Logger:            &mocklogger.MockLogger{},
-		IsSDSUsed:         false,
+		IsEDVUsed:         false,
 	}
 }

--- a/pkg/restapi/kms/operation/models.go
+++ b/pkg/restapi/kms/operation/models.go
@@ -16,7 +16,7 @@ type CreateKeystoreReq struct {
 
 // UpdateCapabilityReq update capability request.
 type UpdateCapabilityReq struct {
-	OperationalEDVCapability json.RawMessage `json:"operationalEDVCapability,omitempty"`
+	EDVCapability json.RawMessage `json:"edvCapability,omitempty"`
 }
 
 type createKeyReq struct {

--- a/pkg/restapi/kms/operation/operations.go
+++ b/pkg/restapi/kms/operation/operations.go
@@ -83,7 +83,7 @@ type Operation struct {
 	keystoreService   keystore.Service
 	kmsServiceCreator func(req *http.Request) (kms.Service, error)
 	logger            log.Logger
-	isSDSUsed         bool
+	isEDVUsed         bool
 	authService       authService
 }
 
@@ -92,7 +92,7 @@ type Config struct {
 	KeystoreService   keystore.Service
 	KMSServiceCreator func(req *http.Request) (kms.Service, error)
 	Logger            log.Logger
-	IsSDSUsed         bool
+	IsEDVUsed         bool
 	AuthService       authService
 }
 
@@ -102,7 +102,7 @@ func New(config *Config) *Operation {
 		keystoreService:   config.KeystoreService,
 		kmsServiceCreator: config.KMSServiceCreator,
 		logger:            config.Logger,
-		isSDSUsed:         config.IsSDSUsed,
+		isEDVUsed:         config.IsEDVUsed,
 		authService:       config.AuthService,
 	}
 
@@ -142,11 +142,11 @@ func (o *Operation) createKeystoreHandler(rw http.ResponseWriter, req *http.Requ
 		keystore.WithCreatedAt(&createdAt),
 	}
 
-	if o.isSDSUsed {
+	if o.isEDVUsed {
 		opts = append(opts,
 			keystore.WithRecipientKeyType(arieskms.ECDH256KWAES256GCM),
 			keystore.WithMACKeyType(arieskms.HMACSHA256Tag256),
-			keystore.WithOperationalVaultID(request.VaultID),
+			keystore.WithVaultID(request.VaultID),
 		)
 	}
 
@@ -201,8 +201,8 @@ func (o *Operation) updateCapabilityHandler(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	if len(request.OperationalEDVCapability) == 0 {
-		o.writeErrorResponse(rw, http.StatusBadRequest, "operationalEDVCapability is empty",
+	if len(request.EDVCapability) == 0 {
+		o.writeErrorResponse(rw, http.StatusBadRequest, "edvCapability is empty",
 			fmt.Errorf(""))
 
 		return
@@ -217,7 +217,7 @@ func (o *Operation) updateCapabilityHandler(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	ks.OperationalEDVCapability = request.OperationalEDVCapability
+	ks.EDVCapability = request.EDVCapability
 
 	if err := o.keystoreService.Save(ks); err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, saveKeystoreFailure, err)

--- a/pkg/storage/edv/edvstorage_test.go
+++ b/pkg/storage/edv/edvstorage_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package sds //nolint:testpackage // need to test local methods
+package edv //nolint:testpackage // need to test local methods
 
 import (
 	"crypto/tls"
@@ -25,7 +25,7 @@ import (
 
 const (
 	testKeystoreID   = "keystoreID"
-	testSDSServerURL = "sds.example.com"
+	testEDVServerURL = "edv.example.com"
 )
 
 func TestSignHeader(t *testing.T) {
@@ -115,7 +115,7 @@ func TestNewProvider(t *testing.T) {
 			KeystoreService: srv,
 			CryptoService:   &mockcrypto.Crypto{ComputeMACErr: errors.New("compute mac error")},
 			TLSConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
-			SDSServerURL:    testSDSServerURL,
+			EDVServerURL:    testEDVServerURL,
 			KeystoreID:      testKeystoreID,
 		}
 
@@ -180,7 +180,7 @@ func buildConfig(keystoreService keystore.Service) *Config {
 		KeystoreService: keystoreService,
 		CryptoService:   &mockcrypto.Crypto{},
 		TLSConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
-		SDSServerURL:    testSDSServerURL,
+		EDVServerURL:    testEDVServerURL,
 		KeystoreID:      testKeystoreID,
 	}
 }

--- a/test/bdd/features/kms_api.feature
+++ b/test/bdd/features/kms_api.feature
@@ -10,9 +10,9 @@ Feature: KMS and crypto operations
   Background:
     Given Key Server is running on "localhost" port "8076"
       And Authz Key Server is running on "localhost" port "8077"
-      And SDS Server is running on "localhost" port "8081"
-      And "Alice" has created a data vault on SDS Server for storing operational keys
-      And "Bob" has created a data vault on SDS Server for storing operational keys
+      And EDV Server is running on "localhost" port "8081"
+      And "Alice" has created a data vault on EDV Server for storing keys
+      And "Bob" has created a data vault on EDV Server for storing keys
 
   Scenario: User creates a key
     Given "Alice" has created an empty keystore on Key Server

--- a/test/bdd/fixtures/edv/.env
+++ b/test/bdd/fixtures/edv/.env
@@ -5,7 +5,7 @@
 #
 
 EDV_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/edv-rest
-EDV_REST_IMAGE_TAG=0.1.5-snapshot-3cda022
+EDV_REST_IMAGE_TAG=0.1.5-snapshot-1dae401
 
 EDV_DATABASE_TYPE=couchdb
 EDV_DATABASE_URL=admin:password@couchdb.example.com:5984

--- a/test/bdd/fixtures/kms/docker-compose.yml
+++ b/test/bdd/fixtures/kms/docker-compose.yml
@@ -22,9 +22,9 @@ services:
       - KMS_SECRETS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_SECRETS_DATABASE_PREFIX=authzkms
       - KMS_SECRETS_MASTER_KEY_PATH=/etc/tls/service-lock.key
-      - KMS_OPERATIONAL_KMS_STORAGE_TYPE=couchdb
-      - KMS_OPERATIONAL_KMS_STORAGE_URL=admin:password@couchdb.example.com:5984
-      - KMS_OPERATIONAL_KMS_STORAGE_PREFIX=ops
+      - KMS_KEY_MANAGER_STORAGE_TYPE=couchdb
+      - KMS_KEY_MANAGER_STORAGE_URL=admin:password@couchdb.example.com:5984
+      - KMS_KEY_MANAGER_STORAGE_PREFIX=authzkms_user
     ports:
       - 8077:8077
     entrypoint: ""
@@ -49,8 +49,8 @@ services:
       - KMS_SECRETS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_SECRETS_DATABASE_PREFIX=kms
       - KMS_SECRETS_MASTER_KEY_PATH=/etc/tls/service-lock.key
-      - KMS_OPERATIONAL_KMS_STORAGE_TYPE=sds
-      - KMS_OPERATIONAL_KMS_STORAGE_URL=https://edv.example.com:8081
+      - KMS_KEY_MANAGER_STORAGE_TYPE=edv
+      - KMS_KEY_MANAGER_STORAGE_URL=https://edv.example.com:8081
     ports:
       - 8076:8076
     entrypoint: ""

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -9,10 +9,10 @@ go 1.15
 require (
 	github.com/cucumber/godog v0.10.0
 	github.com/fsouza/go-dockerclient v1.6.6
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
 	github.com/rs/xid v1.2.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
-	github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
+	github.com/trustbloc/edv v0.1.5-0.20201122203913-1dae4015cad6
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
 )
 

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -513,8 +513,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c h1:kMOoCmU+Ir5ZuV9HU1/Smma9TcuDGGxGJ6fY6q2/fDA=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201120180639-8c0425a6ab6c/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
@@ -817,10 +817,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
-github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8 h1:pfP8WeNQPtei9PfYPpiBWDyewWG+shqwpdMO6X4F+Kk=
-github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8/go.mod h1:5PuBQghP0TP3ZQudjWpqXt1hwqtWOs/Lak1FKtmZofY=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edv v0.1.5-0.20201122203913-1dae4015cad6 h1:3afjtOH4EWBzM9L6VWeRPHVE3gAUz22jwXyZSI46vdQ=
+github.com/trustbloc/edv v0.1.5-0.20201122203913-1dae4015cad6/go.mod h1:QpKdT5XtsilAY/7+/724KvKKKsgIca98OoBn9VYpnsY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/pkg/common/common_steps.go
+++ b/test/bdd/pkg/common/common_steps.go
@@ -42,7 +42,7 @@ func (s *Steps) SetContext(ctx *context.BDDContext) {
 func (s *Steps) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Key Server is running on "([^"]*)" port "([^"]*)"$`, s.checkKeyServerIsRun)
 	ctx.Step(`^Authz Key Server is running on "([^"]*)" port "([^"]*)"$`, s.checkAuthzKeyServerIsRun)
-	ctx.Step(`^SDS Server is running on "([^"]*)" port "([^"]*)"$`, s.checkSDSServerIsRun)
+	ctx.Step(`^EDV Server is running on "([^"]*)" port "([^"]*)"$`, s.checkEDVServerIsRun)
 }
 
 func (s *Steps) checkKeyServerIsRun(host string, port int) error {
@@ -67,13 +67,13 @@ func (s *Steps) checkAuthzKeyServerIsRun(host string, port int) error {
 	return nil
 }
 
-func (s *Steps) checkSDSServerIsRun(host string, port int) error {
+func (s *Steps) checkEDVServerIsRun(host string, port int) error {
 	url, err := s.healthCheck(host, port)
 	if err != nil {
 		return err
 	}
 
-	s.bddContext.SDSServerURL = url
+	s.bddContext.EDVServerURL = url
 
 	return nil
 }

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -24,7 +24,7 @@ import (
 type BDDContext struct {
 	KeyServerURL      string
 	AuthzKeyServerURL string
-	SDSServerURL      string
+	EDVServerURL      string
 	tlsConfig         *tls.Config
 	KeyManager        kms.KeyManager
 	Crypto            cryptoapi.Crypto


### PR DESCRIPTION
This PR does the following renaming:
* SDS -> EDV
* Operational KMS -> Key Manager
* OperationalVaultID -> VaultID
* OperationalEDVCapability -> EDVCapability
* OperationalKeyIDs -> KeyIDs