### PR TITLE
feat: secretlock with split secret shares

### DIFF
--- a/cmd/kms-rest/go.mod
+++ b/cmd/kms-rest/go.mod
@@ -8,7 +8,7 @@ go 1.15
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/cmd/kms-rest/go.sum
+++ b/cmd/kms-rest/go.sum
@@ -399,6 +399,7 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT5E/Cl7cNS5nU=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -461,6 +462,7 @@ github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pN
 github.com/hashicorp/raft-snapshot v1.0.2-0.20190827162939-8117efcc5aab/go.mod h1:5sL9eUn72lH5DzsFIJ9jaysITbHksSSszImWSOTC8Ic=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.3/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
+github.com/hashicorp/vault v1.2.1-0.20200911125421-dba37adcb55a h1:4cBHXpugMTz4anYA27/SmM2a7c2+ot99UsrBSE1+DLM=
 github.com/hashicorp/vault v1.2.1-0.20200911125421-dba37adcb55a/go.mod h1:5AXfH3xGJffb77funy/WHkcsQfpTYwTZo6PkDl8iOrk=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.5.5/go.mod h1:sQ+VNwPQlemgXHXikYH6onfH9gPwDZ1GUVRLz0ZvHx8=
 github.com/hashicorp/vault-plugin-auth-azure v0.5.6/go.mod h1:xUpcusehlkR1cNbA+wNta9W4slS64pYe7CXx5UYM2OQ=
@@ -515,8 +517,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9/go.mod h1:cLWhBbjgrA04Di9ufGqAuTCdoM33Xq4Cuc3fL/VLAgI=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201028195746-556cee009e20/go.mod h1:UF34fHG3WLB1QSxeIqDrWDhK98GLqA09NauwultnG7w=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e h1:QluQFRvFRSYExodztwD1RS6bTRcqGZSjTuRpPCrOek0=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587 h1:/G0Cwa24V9sMrqD4LFZNDOU+41Of/kr7wpNq/v76hI8=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5 h1:lcnsNy983eXWEhi3uWFq/RV4ut6umrMQj/V7FtZ175A=

--- a/cmd/kms-rest/startcmd/start_test.go
+++ b/cmd/kms-rest/startcmd/start_test.go
@@ -287,7 +287,7 @@ func TestStartCmdWithMasterKeyPathParam(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("Fail with invalid kms-secrets-master-key-path arg", func(t *testing.T) {
+	t.Run("Fail with invalid kms-master-key-path arg", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
 		args := requiredArgs()
@@ -298,6 +298,18 @@ func TestStartCmdWithMasterKeyPathParam(t *testing.T) {
 		err := startCmd.Execute()
 		require.Error(t, err)
 	})
+}
+
+func TestStartCmdWithHubAuthURLParam(t *testing.T) {
+	startCmd := GetStartCmd(&mockServer{})
+
+	args := requiredArgs()
+	args = append(args, "--"+hubAuthURLFlagName, "http://example.com")
+
+	startCmd.SetArgs(args)
+
+	err := startCmd.Execute()
+	require.NoError(t, err)
 }
 
 func TestStartKMSService(t *testing.T) {

--- a/docs/kms_rest_cli.md
+++ b/docs/kms_rest_cli.md
@@ -21,6 +21,8 @@ Parameters can be set by command line arguments or environment variables:
     --tls-serve-cert string                   Path to the server certificate to use when serving HTTPS. Alternatively, this can be set with the following environment variable: KMS_TLS_SERVE_CERT
     --tls-serve-key string                    Path to the private key to use when serving HTTPS. Alternatively, this can be set with the following environment variable: KMS_TLS_SERVE_KEY
 
+    --kms-master-key-path string              The path to the file with master key to be used for secret lock. If missing noop service lock is used. Alternatively, this can be set with the following environment variable: KMS_MASTER_KEY_PATH
+
     --database-type string                    The type of database to use for storing metadata about keystores and associated keys. Supported options: mem, couchdb. Alternatively, this can be set with the following environment variable: KMS_DATABASE_TYPE
     --database-url string                     The URL of the database. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_DATABASE_URL
     --database-prefix string                  An optional prefix to be used when creating and retrieving underlying databases. Alternatively, this can be set with the following environment variable: KMS_DATABASE_PREFIX
@@ -29,11 +31,11 @@ Parameters can be set by command line arguments or environment variables:
     --kms-secrets-database-url string         The URL of the database for KMS secrets. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_SECRETS_DATABASE_URL
     --kms-secrets-database-prefix string      An optional prefix to be used when creating and retrieving the underlying KMS secrets database. Alternatively, this can be set with the following environment variable: KMS_SECRETS_DATABASE_PREFIX
 
-    --kms-secrets-master-key-path string      The path to the file with master key to be used for secret lock. If missing noop service lock is used. Alternatively, this can be set with the following environment variable: KMS_SECRETS_MASTER_KEY_PATH
-
     --key-manager-storage-type string         The type of storage to use for user's key manager. Supported options: mem, couchdb, edv. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_TYPE
     --key-manager-storage-url string          The URL of storage for user's key manager. Not needed if using in-memory storage. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_URL
     --key-manager-storage-prefix string       An optional prefix to be used when creating and retrieving the underlying user's key manager storage. Alternatively, this can be set with the following environment variable: KMS_KEY_MANAGER_STORAGE_PREFIX
+
+    --hub-auth-url string                     The URL of Hub Auth server to use for fetching secret share for secret lock. If not specified secret lock based on master key is used. Alternatively, this can be set with the following environment variable: KMS_HUB_AUTH_URL
 ```
 
 ## Example

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/tink/go v1.5.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/rs/xid v1.2.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e h1:QluQFRvFRSYExodztwD1RS6bTRcqGZSjTuRpPCrOek0=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/pkg/internal/support/httpclient.go
+++ b/pkg/internal/support/httpclient.go
@@ -1,0 +1,14 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package support
+
+import "net/http"
+
+// HTTPClient represents an HTTP client.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/pkg/secretlock/resolver.go
+++ b/pkg/secretlock/resolver.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretlock
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+)
+
+// Resolver resolves secret lock for the request.
+type Resolver interface {
+	Resolve(req *http.Request) (secretlock.Service, error)
+}

--- a/pkg/secretlock/secretsplitlock/secret_split_lock.go
+++ b/pkg/secretlock/secretsplitlock/secret_split_lock.go
@@ -1,0 +1,127 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretsplitlock
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/hkdf"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/edge-core/pkg/sss"
+
+	"github.com/trustbloc/hub-kms/pkg/internal/support"
+)
+
+const (
+	secretHeader      = "Hub-Kms-Secret" //nolint:gosec // header with secret A
+	userHeader        = "Hub-Kms-User"   // header with a value that represent a user ("subject")
+	hubAuthSecretPath = "/secret"        // path on Hub Auth to get secret B
+)
+
+// Config defines configuration for the secret split lock.
+type Config struct {
+	HubAuthURL      string
+	HubAuthAPIToken string
+	HTTPClient      support.HTTPClient
+	SecretSplitter  sss.SecretSplitter
+	Logger          log.Logger
+}
+
+type secretSplitLock struct {
+	hubAuthURL      string
+	hubAuthAPIToken string
+	httpClient      support.HTTPClient
+	secretSplitter  sss.SecretSplitter
+	logger          log.Logger
+}
+
+// New returns a new secret split lock instance.
+func New(config *Config) *secretSplitLock { //nolint:golint // no need for secretSplitLock to be exported
+	return &secretSplitLock{
+		hubAuthURL:      config.HubAuthURL,
+		hubAuthAPIToken: config.HubAuthAPIToken,
+		httpClient:      config.HTTPClient,
+		secretSplitter:  config.SecretSplitter,
+		logger:          config.Logger,
+	}
+}
+
+// Resolver resolves secret lock for the request.
+func (s *secretSplitLock) Resolve(r *http.Request) (secretlock.Service, error) {
+	secretA := r.Header.Get(secretHeader)
+	if secretA == "" {
+		return nil, errors.New("empty secret A")
+	}
+
+	sub := r.Header.Get(userHeader)
+
+	secretB, err := s.getSecretB(sub)
+	if err != nil {
+		return nil, fmt.Errorf("get secret B: %w", err)
+	}
+
+	combined, err := s.secretSplitter.Combine([][]byte{[]byte(secretA), secretB})
+	if err != nil {
+		return nil, fmt.Errorf("combine secrets: %w", err)
+	}
+
+	secLock, err := hkdf.NewMasterLock(string(combined), sha256.New, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new master lock: %w", err)
+	}
+
+	return secLock, nil
+}
+
+func (s *secretSplitLock) getSecretB(sub string) ([]byte, error) {
+	uri := fmt.Sprintf("%s/%s?sub=%s", s.hubAuthURL, hubAuthSecretPath, url.QueryEscape(sub))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("authorization",
+		fmt.Sprintf("Bearer %s", base64.StdEncoding.EncodeToString([]byte(s.hubAuthAPIToken))),
+	)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			s.logger.Errorf("failed to close response body")
+		}
+	}()
+
+	var secretResp struct {
+		Secret string `json:"secret"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&secretResp)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := base64.StdEncoding.DecodeString(secretResp.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/pkg/secretlock/secretsplitlock/secret_split_lock_test.go
+++ b/pkg/secretlock/secretsplitlock/secret_split_lock_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretsplitlock_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/edge-core/pkg/log/mocklogger"
+	"github.com/trustbloc/edge-core/pkg/sss"
+
+	"github.com/trustbloc/hub-kms/pkg/internal/support"
+	"github.com/trustbloc/hub-kms/pkg/secretlock/secretsplitlock"
+)
+
+const (
+	testHubAuthURL      = "https://hub-auth.example.com"
+	testHubAuthAPIToken = "token"
+)
+
+func TestResolve(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		r := secretsplitlock.New(newConfig(t))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.NotNil(t, secLock)
+		require.NoError(t, err)
+	})
+
+	t.Run("Error: empty secret A", func(t *testing.T) {
+		r := secretsplitlock.New(newConfig(t))
+
+		secLock, err := r.Resolve(buildReq(""))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty secret A")
+	})
+
+	t.Run("Fail to get secret B: response error", func(t *testing.T) {
+		httpClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("response error")
+			},
+		}
+
+		r := secretsplitlock.New(newConfig(t, withHTTPClient(httpClient)))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get secret B: response error")
+	})
+
+	t.Run("Fail to get secret B: read body error", func(t *testing.T) {
+		r := secretsplitlock.New(newConfig(t, withResponseBody(ioutil.NopCloser(&failingReader{}))))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get secret B: read error")
+	})
+
+	t.Run("Fail to get secret B: secret decode error", func(t *testing.T) {
+		r := secretsplitlock.New(newConfig(t, withSecret("test secret")))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get secret B: illegal base64 data")
+	})
+
+	t.Run("Error: combine secrets", func(t *testing.T) {
+		splitter := &mockSplitter{
+			CombineErr: errors.New("combine error"),
+		}
+
+		r := secretsplitlock.New(newConfig(t, withSecretSplitter(splitter)))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "combine secrets: combine error")
+	})
+
+	t.Run("Error: new master lock: passphrase is empty", func(t *testing.T) {
+		splitter := &mockSplitter{
+			CombineValue: []byte(""),
+		}
+
+		r := secretsplitlock.New(newConfig(t, withSecretSplitter(splitter)))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.Nil(t, secLock)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new master lock: passphrase is empty")
+	})
+
+	t.Run("Log when fail to close response body", func(t *testing.T) {
+		logger := &mocklogger.MockLogger{}
+
+		resp := struct {
+			Secret string `json:"secret"`
+		}{
+			Secret: base64.StdEncoding.EncodeToString([]byte("test secret")),
+		}
+
+		b, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		r := secretsplitlock.New(newConfig(t,
+			withResponseBody(&failingCloser{bytes.NewReader(b)}),
+			withLogger(logger),
+		))
+
+		secLock, err := r.Resolve(buildReq("secretA"))
+
+		require.NotNil(t, secLock)
+		require.NoError(t, err)
+		require.Contains(t, logger.ErrorLogContents, "failed to close response body")
+	})
+}
+
+func buildReq(secret string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "https://kms.example.com", nil)
+
+	if secret != "" {
+		req.Header.Set("Hub-Kms-Secret", secret)
+	}
+
+	req.Header.Set("Hub-Kms-User", "user")
+
+	return req
+}
+
+type mockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+type mockSplitter struct {
+	CombineValue []byte
+	CombineErr   error
+}
+
+func (m *mockSplitter) Split(secret []byte, numParts, threshold int) ([][]byte, error) {
+	return nil, nil
+}
+
+func (m *mockSplitter) Combine(secretParts [][]byte) ([]byte, error) {
+	if m.CombineErr != nil {
+		return nil, m.CombineErr
+	}
+
+	return m.CombineValue, nil
+}
+
+type failingReader struct {
+}
+
+func (*failingReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read error")
+}
+
+type failingCloser struct {
+	io.Reader
+}
+
+func (*failingCloser) Close() error {
+	return errors.New("close error")
+}
+
+type options struct {
+	secret         string
+	body           io.ReadCloser
+	httpClient     support.HTTPClient
+	secretSplitter sss.SecretSplitter
+	logger         log.Logger
+}
+
+type optionFn func(opts *options)
+
+func newConfig(t *testing.T, opts ...optionFn) *secretsplitlock.Config {
+	t.Helper()
+
+	cOpts := &options{
+		secret:         base64.StdEncoding.EncodeToString([]byte("test secret")),
+		secretSplitter: &mockSplitter{CombineValue: []byte("combined secret")},
+		logger:         &mocklogger.MockLogger{},
+	}
+
+	for i := range opts {
+		opts[i](cOpts)
+	}
+
+	if cOpts.httpClient == nil {
+		if cOpts.body == nil {
+			resp := struct {
+				Secret string `json:"secret"`
+			}{
+				Secret: cOpts.secret,
+			}
+
+			b, err := json.Marshal(resp)
+			require.NoError(t, err)
+
+			cOpts.body = ioutil.NopCloser(bytes.NewReader(b))
+		}
+
+		cOpts.httpClient = &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       cOpts.body,
+				}, nil
+			},
+		}
+	}
+
+	config := &secretsplitlock.Config{
+		HubAuthURL:      testHubAuthURL,
+		HubAuthAPIToken: testHubAuthAPIToken,
+		HTTPClient:      cOpts.httpClient,
+		SecretSplitter:  cOpts.secretSplitter,
+		Logger:          cOpts.logger,
+	}
+
+	return config
+}
+
+func withSecret(secret string) optionFn {
+	return func(o *options) {
+		o.secret = secret
+	}
+}
+
+func withResponseBody(body io.ReadCloser) optionFn {
+	return func(o *options) {
+		o.body = body
+	}
+}
+
+func withHTTPClient(client support.HTTPClient) optionFn {
+	return func(o *options) {
+		o.httpClient = client
+	}
+}
+
+func withSecretSplitter(splitter sss.SecretSplitter) optionFn {
+	return func(o *options) {
+		o.secretSplitter = splitter
+	}
+}
+
+func withLogger(logger log.Logger) optionFn {
+	return func(o *options) {
+		o.logger = logger
+	}
+}

--- a/test/bdd/fixtures/kms/docker-compose.yml
+++ b/test/bdd/fixtures/kms/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
       - KMS_TLS_SERVE_KEY=/etc/tls/ec-key.pem
+      - KMS_MASTER_KEY_PATH=/etc/tls/service-lock.key
       - KMS_DATABASE_TYPE=couchdb
       - KMS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_DATABASE_PREFIX=authzkeystore
       - KMS_SECRETS_DATABASE_TYPE=couchdb
       - KMS_SECRETS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_SECRETS_DATABASE_PREFIX=authzkms
-      - KMS_SECRETS_MASTER_KEY_PATH=/etc/tls/service-lock.key
       - KMS_KEY_MANAGER_STORAGE_TYPE=couchdb
       - KMS_KEY_MANAGER_STORAGE_URL=admin:password@couchdb.example.com:5984
       - KMS_KEY_MANAGER_STORAGE_PREFIX=authzkms_user
@@ -42,13 +42,13 @@ services:
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
       - KMS_TLS_SERVE_KEY=/etc/tls/ec-key.pem
+      - KMS_MASTER_KEY_PATH=/etc/tls/service-lock.key
       - KMS_DATABASE_TYPE=couchdb
       - KMS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_DATABASE_PREFIX=keystore
       - KMS_SECRETS_DATABASE_TYPE=couchdb
       - KMS_SECRETS_DATABASE_URL=admin:password@couchdb.example.com:5984
       - KMS_SECRETS_DATABASE_PREFIX=kms
-      - KMS_SECRETS_MASTER_KEY_PATH=/etc/tls/service-lock.key
       - KMS_KEY_MANAGER_STORAGE_TYPE=edv
       - KMS_KEY_MANAGER_STORAGE_URL=https://edv.example.com:8081
     ports:

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -9,10 +9,10 @@ go 1.15
 require (
 	github.com/cucumber/godog v0.10.0
 	github.com/fsouza/go-dockerclient v1.6.6
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e
 	github.com/rs/xid v1.2.1
 	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
-	github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8
+	github.com/trustbloc/edv v0.1.5-0.20201125123749-8cff541c50ca
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
 )
 

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -513,8 +513,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd h1:xoE9iE/ij9qR4LvAP/ubME2dz/7eB6CLhNvK/M1iGrI=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201123085011-2625d433b8fd/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e h1:QluQFRvFRSYExodztwD1RS6bTRcqGZSjTuRpPCrOek0=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201124194436-a37f1c10fd4e/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
@@ -817,14 +817,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
-github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8 h1:pfP8WeNQPtei9PfYPpiBWDyewWG+shqwpdMO6X4F+Kk=
-github.com/trustbloc/edv v0.1.5-0.20201121163745-3cda022e7ae8/go.mod h1:5PuBQghP0TP3ZQudjWpqXt1hwqtWOs/Lak1FKtmZofY=
+github.com/trustbloc/edv v0.1.5-0.20201125123749-8cff541c50ca h1:Y3KDQyMjzctZdd9bSapsEB6KG/zJIJq+wA0cXTU74tY=
+github.com/trustbloc/edv v0.1.5-0.20201125123749-8cff541c50ca/go.mod h1:QpKdT5XtsilAY/7+/724KvKKKsgIca98OoBn9VYpnsY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/pkg/kms/steps.go
+++ b/test/bdd/pkg/kms/steps.go
@@ -798,8 +798,7 @@ func buildURI(endpoint, keystoreID, keyID string) string {
 
 func headers() map[string]string {
 	return map[string]string{
-		"Content-Type":   "application/json",
-		"Hub-Kms-Secret": "p@ssphrase",
+		"Content-Type": "application/json",
 	}
 }
 


### PR DESCRIPTION
Adds support for secretlock with split secret shares where one part comes in a header and the other should be fetched from Hub Auth. BDD tests will come in the next PR.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>