### PR TITLE
feat: CapabilityInvocationAction for clients

### DIFF
--- a/pkg/restapi/kms/operation/middleware.go
+++ b/pkg/restapi/kms/operation/middleware.go
@@ -9,6 +9,7 @@ package operation
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
@@ -139,6 +140,50 @@ func expectedAction(n namer) (string, error) { // nolint:gocyclo // necessary co
 		action = actionUnwrap
 	default:
 		err = fmt.Errorf("unsupported endpoint: %s", n.GetName())
+	}
+
+	return action, err
+}
+
+// CapabilityInvocationAction returns the action to invoke on the capability given the request.
+func CapabilityInvocationAction(r *http.Request) (string, error) { // nolint:gocyclo // ignore due to switch stmt
+	idx := strings.LastIndex(r.URL.Path, "/")
+	if idx == -1 {
+		return "", fmt.Errorf("invalid path format: %s", r.URL.Path)
+	}
+
+	lastPathComponent := r.URL.Path[idx:]
+
+	var (
+		action string
+		err    error
+	)
+
+	switch lastPathComponent {
+	case keysPath:
+		action = actionCreateKey
+	case capabilityPath:
+		action = actionStoreCapability
+	case exportPath:
+		action = actionExportKey
+	case signPath:
+		action = actionSign
+	case verifyPath:
+		action = actionVerify
+	case encryptPath:
+		action = actionEncrypt
+	case decryptPath:
+		action = actionDecrypt
+	case computeMACPath:
+		action = actionComputeMac
+	case verifyMACPath:
+		action = actionVerifyMAC
+	case wrapPath:
+		action = actionWrap
+	case unwrapPath:
+		action = actionUnwrap
+	default:
+		err = fmt.Errorf("unsupported endpoint: %s", r.URL.Path)
 	}
 
 	return action, err

--- a/pkg/restapi/kms/operation/middlware_test.go
+++ b/pkg/restapi/kms/operation/middlware_test.go
@@ -133,6 +133,81 @@ func TestMiddleware(t *testing.T) {
 	})
 }
 
+func TestCapabilityInvocationAction(t *testing.T) {
+	t.Run("returns invocation action", func(t *testing.T) {
+		testCases := []struct {
+			endpoint       string
+			expectedAction string
+		}{
+			{
+				endpoint:       keysEndpoint,
+				expectedAction: actionCreateKey,
+			},
+			{
+				endpoint:       capabilityEndpoint,
+				expectedAction: actionStoreCapability,
+			},
+			{
+				endpoint:       exportEndpoint,
+				expectedAction: actionExportKey,
+			},
+			{
+				endpoint:       signEndpoint,
+				expectedAction: actionSign,
+			},
+			{
+				endpoint:       verifyEndpoint,
+				expectedAction: actionVerify,
+			},
+			{
+				endpoint:       encryptEndpoint,
+				expectedAction: actionEncrypt,
+			},
+			{
+				endpoint:       decryptEndpoint,
+				expectedAction: actionDecrypt,
+			},
+			{
+				endpoint:       computeMACEndpoint,
+				expectedAction: actionComputeMac,
+			},
+			{
+				endpoint:       verifyMACEndpoint,
+				expectedAction: actionVerifyMAC,
+			},
+			{
+				endpoint:       wrapEndpoint,
+				expectedAction: actionWrap,
+			},
+			{
+				endpoint:       unwrapEndpoint,
+				expectedAction: actionUnwrap,
+			},
+		}
+
+		for i := range testCases {
+			test := testCases[i]
+			result, err := CapabilityInvocationAction(httptest.NewRequest(http.MethodPost, test.endpoint, nil))
+			require.NoError(t, err)
+			require.Equal(t, test.expectedAction, result)
+		}
+	})
+
+	t.Run("fails if request is a relative URL with only one path component", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "/path", nil)
+		request.URL.Path = "path"
+		_, err := CapabilityInvocationAction(request)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid path format")
+	})
+
+	t.Run("fails if endpoint is not supported", func(t *testing.T) {
+		_, err := CapabilityInvocationAction(httptest.NewRequest(http.MethodPost, "/unsupported/path", nil))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported endpoint")
+	})
+}
+
 type mockNamer struct {
 	name string
 }

--- a/pkg/restapi/kms/operation/operations.go
+++ b/pkg/restapi/kms/operation/operations.go
@@ -35,22 +35,34 @@ const (
 	keystoreIDQueryParam = "keystoreID"
 	keyIDQueryParam      = "keyID"
 
+	keysPath       = "/keys"
+	capabilityPath = "/capability"
+	exportPath     = "/export"
+	signPath       = "/sign"
+	verifyPath     = "/verify"
+	encryptPath    = "/encrypt"
+	decryptPath    = "/decrypt"
+	computeMACPath = "/computemac"
+	verifyMACPath  = "/verifymac"
+	wrapPath       = "/wrap"
+	unwrapPath     = "/unwrap"
+
 	// KMSBasePath is the base path for all KMS endpoints.
 	KMSBasePath        = "/kms"
 	keystoresEndpoint  = "/keystores"
 	keystoreEndpoint   = keystoresEndpoint + "/{" + keystoreIDQueryParam + "}"
-	keysEndpoint       = keystoreEndpoint + "/keys"
-	capabilityEndpoint = keystoreEndpoint + "/capability"
+	keysEndpoint       = keystoreEndpoint + keysPath
+	capabilityEndpoint = keystoreEndpoint + capabilityPath
 	keyEndpoint        = keysEndpoint + "/{" + keyIDQueryParam + "}"
-	exportEndpoint     = keyEndpoint + "/export"
-	signEndpoint       = keyEndpoint + "/sign"
-	verifyEndpoint     = keyEndpoint + "/verify"
-	encryptEndpoint    = keyEndpoint + "/encrypt"
-	decryptEndpoint    = keyEndpoint + "/decrypt"
-	computeMACEndpoint = keyEndpoint + "/computemac"
-	verifyMACEndpoint  = keyEndpoint + "/verifymac"
-	wrapEndpoint       = keystoreEndpoint + "/wrap" // kms/keystores/{keystoreID}/wrap
-	unwrapEndpoint     = keyEndpoint + "/unwrap"    // kms/keystores/{keystoreID}/keys/{keyID}/unwrap
+	exportEndpoint     = keyEndpoint + exportPath
+	signEndpoint       = keyEndpoint + signPath
+	verifyEndpoint     = keyEndpoint + verifyPath
+	encryptEndpoint    = keyEndpoint + encryptPath
+	decryptEndpoint    = keyEndpoint + decryptPath
+	computeMACEndpoint = keyEndpoint + computeMACPath
+	verifyMACEndpoint  = keyEndpoint + verifyMACPath
+	wrapEndpoint       = keystoreEndpoint + wrapPath // kms/keystores/{keystoreID}/wrap
+	unwrapEndpoint     = keyEndpoint + unwrapPath    // kms/keystores/{keystoreID}/keys/{keyID}/unwrap
 
 	// Error messages.
 	receivedBadRequest      = "Received bad request: %s"


### PR DESCRIPTION
Clients can use this function to set the correct capability invocation action when calling endpoints authz'ed with ZCAPLD.

Will be used in agent-sdk [here](https://github.com/trustbloc/agent-sdk/blob/ecdf2dd60884227271746ca4ee683abbcf7a7b3c/cmd/agent-js-worker/main.go#L684-L683) when injecting the custom headers function for the `webkms` client.

Signed-off-by: George Aristy <george.aristy@securekey.com>