### PR TITLE
refactor: Create Key store - return location in body

### DIFF
--- a/pkg/restapi/kms/operation/models.go
+++ b/pkg/restapi/kms/operation/models.go
@@ -23,6 +23,10 @@ type createKeyReq struct {
 	KeyType string `json:"keyType"`
 }
 
+type createKeyResp struct {
+	Location string `json:"location"`
+}
+
 type exportKeyResp struct {
 	PublicKey string `json:"publicKey"`
 }

--- a/pkg/restapi/kms/operation/operations.go
+++ b/pkg/restapi/kms/operation/operations.go
@@ -245,10 +245,17 @@ func (o *Operation) createKeyHandler(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	rw.Header().Set("Location", keyLocation(req.Host, keystoreID, keyID))
+	location := keyLocation(req.Host, keystoreID, keyID)
+
+	rw.Header().Set("Location", location)
 	rw.WriteHeader(http.StatusCreated)
 
-	o.logger.Debugf("Location: %s", keyLocation(req.Host, keystoreID, keyID))
+	// refer - https://github.com/trustbloc/hub-kms/issues/114
+	o.writeResponse(rw, createKeyResp{
+		Location: location,
+	})
+
+	o.logger.Debugf("Location: %s", location)
 	o.logger.Debugf("finished handling request")
 }
 


### PR DESCRIPTION
The JS/wasm clients can access only [simple headers when making cross-origin requests](https://javascript.info/fetch-crossorigin#response-headers) and location is not part of it.

closes #114 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>