### PR TITLE
fix: host URL returned in the Location header

### DIFF
--- a/cmd/kms-rest/startcmd/start_test.go
+++ b/cmd/kms-rest/startcmd/start_test.go
@@ -68,7 +68,7 @@ func TestStartCmdContents(t *testing.T) {
 
 func TestStartCmdWithBlankArg(t *testing.T) {
 	flags := []string{
-		hostURLFlagName, logLevelFlagName,
+		hostURLFlagName, baseURLFlagName, logLevelFlagName,
 		tlsServeCertPathFlagName, tlsServeKeyPathFlagName, secretLockKeyPathFlagName,
 		databaseTypeFlagName, databaseURLFlagName, databasePrefixFlagName,
 		primaryKeyDatabaseTypeFlagName, primaryKeyDatabaseURLFlagName, primaryKeyDatabasePrefixFlagName,

--- a/pkg/restapi/kms/operation/middleware.go
+++ b/pkg/restapi/kms/operation/middleware.go
@@ -30,6 +30,7 @@ func (o *Operation) ZCAPLDMiddleware(h http.Handler) http.Handler {
 		crpto:     o.authService.Crypto(),
 		logger:    o.logger,
 		routeFunc: (&muxNamer{}).GetName,
+		baseURL:   o.baseURL,
 	}
 }
 
@@ -52,6 +53,7 @@ type mwHandler struct {
 	logger      log.Logger
 	ldDocLoader ld.DocumentLoader
 	routeFunc   func(*http.Request) namer
+	baseURL     string
 }
 
 func (h *mwHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +66,7 @@ func (h *mwHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resource := keystoreLocation(r.Host, mux.Vars(r)[keystoreIDQueryParam])
+	resource := keystoreLocation(h.baseURL, mux.Vars(r)[keystoreIDQueryParam])
 
 	expectations := &zcapld.InvocationExpectations{
 		Target:         resource,

--- a/test/bdd/fixtures/kms/docker-compose.yml
+++ b/test/bdd/fixtures/kms/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: ${KMS_REST_IMAGE}:latest
     environment:
       - KMS_HOST_URL=0.0.0.0:8077
+      - KMS_BASE_URL=https://authz-kms.example.com:8077
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
       - KMS_TLS_SERVE_KEY=/etc/tls/ec-key.pem
@@ -45,6 +46,7 @@ services:
     image: ${KMS_REST_IMAGE}:latest
     environment:
       - KMS_HOST_URL=0.0.0.0:8076
+      - KMS_BASE_URL=https://kms.example.com:8077
       - KMS_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - KMS_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
       - KMS_TLS_SERVE_KEY=/etc/tls/ec-key.pem

--- a/test/bdd/pkg/kms/user.go
+++ b/test/bdd/pkg/kms/user.go
@@ -177,8 +177,8 @@ func processHeaders(header http.Header) map[string]string {
 
 func parseLocationHeader(header http.Header) (string, string) {
 	const (
-		keystoreIDPos = 3 // localhost:8076/kms/keystores/{keystoreID}
-		keyIDPos      = 5 // localhost:8076/kms/keystores/{keystoreID}/keys/{keyID}
+		keystoreIDPos = 5 // https://localhost:8076/kms/keystores/{keystoreID}
+		keyIDPos      = 7 // https://localhost:8076/kms/keystores/{keystoreID}/keys/{keyID}
 	)
 
 	location := header.Get("Location")


### PR DESCRIPTION
Adds base URL that can be set in startup parameters. The specified value
will be added to the URL in the Location header. If base URL is empty,
bare location (without schema, host, and port) is returned.

Fixes #119

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>