### PR TITLE
test: add BDD tests for Easy/EasyOpen CryptoBox operations

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
           }
           trap logout EXIT
           echo $DOCKER_PASSWORD | docker login docker.pkg.github.com --username $DOCKER_USER --password-stdin
-          echo '127.0.0.1 third.party.oidc.provider.example.com' | sudo tee -a /etc/hosts
+          echo '127.0.0.1 oidc.provider.example.com' | sudo tee -a /etc/hosts
           make bdd-test
         env:
           DOCKER_USER: $(DOCKER_USER)

--- a/cmd/kms-rest/go.mod
+++ b/cmd/kms-rest/go.mod
@@ -8,7 +8,7 @@ go 1.15
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587
 	github.com/piprate/json-gold v0.3.0
 	github.com/rs/cors v1.7.0
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/net v0.0.0-20201201195509-5d6afe98e0b7 // indirect
 )
 
 replace (

--- a/cmd/kms-rest/go.sum
+++ b/cmd/kms-rest/go.sum
@@ -517,8 +517,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9/go.mod h1:cLWhBbjgrA04Di9ufGqAuTCdoM33Xq4Cuc3fL/VLAgI=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201028195746-556cee009e20/go.mod h1:UF34fHG3WLB1QSxeIqDrWDhK98GLqA09NauwultnG7w=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893 h1:cK1lAVgtoWhUJ2vE8OqiIRsdqTxpM0/nkUqUxQ4TOUc=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb h1:GbE4c+PWz8xZPcZwmKd6jrS8Iwo0j1GJs2UszBbfJTw=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587 h1:/G0Cwa24V9sMrqD4LFZNDOU+41Of/kr7wpNq/v76hI8=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5 h1:lcnsNy983eXWEhi3uWFq/RV4ut6umrMQj/V7FtZ175A=
@@ -997,8 +997,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201009032441-dbdefad45b89 h1:1GKfLldebiSdhTlt3nalwrb7L40Tixr/0IH+kSbRgmk=
 golang.org/x/net v0.0.0-20201009032441-dbdefad45b89/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201201195509-5d6afe98e0b7 h1:3uJsdck53FDIpWwLeAXlia9p4C8j0BO2xZrqzKpL0D8=
+golang.org/x/net v0.0.0-20201201195509-5d6afe98e0b7/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/tink/go v1.5.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/piprate/json-gold v0.3.0
 	github.com/rs/xid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893 h1:cK1lAVgtoWhUJ2vE8OqiIRsdqTxpM0/nkUqUxQ4TOUc=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb h1:GbE4c+PWz8xZPcZwmKd6jrS8Iwo0j1GJs2UszBbfJTw=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/pkg/restapi/kms/operation/operations.go
+++ b/pkg/restapi/kms/operation/operations.go
@@ -871,5 +871,8 @@ func allActions() []string {
 		actionEncrypt,
 		actionDecrypt,
 		actionStoreCapability,
+		actionEasy,
+		actionEasyOpen,
+		actionSealOpen,
 	}
 }

--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -19,9 +19,9 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = localhost
 DNS.2 = edv.example.com
-DNS.3 = third.party.oidc.provider.example.com
-DNS.4 = auth.rest.hydra.example.com
-DNS.5 = auth.rest.example.com
+DNS.3 = oidc.provider.example.com
+DNS.4 = hydra.example.com
+DNS.5 = hub-auth.example.com
 DNS.6 = *.example.com" >> "$tmp"
 
 #create CA

--- a/test/bdd/features/kms_crypto_box_api.feature
+++ b/test/bdd/features/kms_crypto_box_api.feature
@@ -1,0 +1,32 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@kms_crypto_box
+Feature: KMS CryptoBox operations
+  Background:
+    Given Key Server is running on "localhost" port "4466"
+      And AuthZ Key Server is running on "localhost" port "4455"
+      And Hub Auth is running on "localhost" port "8070"
+      And EDV is running on "localhost" port "8081"
+      And "Alice" wallet has stored secret on Hub Auth
+      And "Bob" wallet has stored secret on Hub Auth
+      And "Alice" has created a data vault on EDV for storing keys
+      And "Bob" has created a data vault on EDV for storing keys
+
+  Scenario: Easy/EasyOpen
+    Given "Alice" has created a keystore with "ED25519" key on Key Server
+      And "Bob" has created a keystore with "ED25519" key on Key Server
+      And "Alice" has a public key of "Bob"
+      And "Bob" has a public key of "Alice"
+
+    When  "Alice" makes an HTTP POST to "https://localhost:4466/kms/keystores/{keystoreID}/keys/{keyID}/easy" to easy "test payload" for "Bob"
+    Then  "Alice" gets a response with HTTP status "200 OK"
+     And  "Alice" gets a response with non-empty "cipherText"
+
+    When  "Bob" makes an HTTP POST to "https://localhost:4466/kms/keystores/{keystoreID}/easyopen" to easyOpen "cipherText" from "Alice"
+    Then  "Bob" gets a response with HTTP status "200 OK"
+     And  "Bob" gets a response with "plainText" with value "test payload"

--- a/test/bdd/fixtures/auth/.env
+++ b/test/bdd/fixtures/auth/.env
@@ -5,8 +5,9 @@
 #
 
 AUTH_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/auth-rest
-AUTH_REST_IMAGE_TAG=0.1.4-snapshot-7936a8c
+AUTH_REST_IMAGE_TAG=0.1.4-snapshot-48d4c6f
 
 HYDRA_IMAGE_TAG=v1.3.2-alpine
 MYSQL_IMAGE_TAG=8.0.20
+
 MOCK_LOGIN_CONSENT_IMAGE=mockloginconsent

--- a/test/bdd/fixtures/auth/docker-compose.yml
+++ b/test/bdd/fixtures/auth/docker-compose.yml
@@ -8,8 +8,8 @@ version: '2'
 
 services:
 
-  auth.rest.example.com:
-    container_name: auth.rest.example.com
+  hub-auth.example.com:
+    container_name: hub-auth.example.com
     image: ${AUTH_REST_IMAGE}:${AUTH_REST_IMAGE_TAG}
     environment:
       - AUTH_REST_HOST_URL=0.0.0.0:8070
@@ -18,44 +18,43 @@ services:
       - AUTH_REST_TLS_SERVE_CERT=/etc/keys/tls/ec-pubCert.pem
       - AUTH_REST_TLS_SERVE_KEY=/etc/keys/tls/ec-key.pem
       - AUTH_REST_DATABASE_TYPE=mysql
-      - AUTH_REST_DATABASE_URL=authrest:authrest-secret-pw@tcp(mysql:3306)/
-      - AUTH_REST_DATABASE_PREFIX=authrest
+      - AUTH_REST_DATABASE_URL=hubauth:hubauth-secret-pw@tcp(mysql:3306)/
+      - AUTH_REST_DATABASE_PREFIX=hubauth
       - AUTH_REST_OIDC_CALLBACK=https://localhost:8070/oauth2/callback
-      - AUTH_REST_GOOGLE_URL=https://third.party.oidc.provider.example.com:5555/
-      - AUTH_REST_GOOGLE_CLIENTID=hub-auth
-      - AUTH_REST_GOOGLE_CLIENTSECRET=hub-auth-secret
+      - AUTH_REST_OIDC_PROVIDERS_CONFIG=/etc/oidc-config/providers.yaml
       - AUTH_REST_SDS_DOCS_URL=https://TODO.docs.sds.org/
       - AUTH_REST_SDS_OPSKEYS_URL=https://TODO.keys.sds.org/
       - AUTH_REST_KEYSERVER_AUTH_URL=https://TODO.auth.keyserver.org/
       - AUTH_REST_KEYSERVER_OPS_URL=https://TODO.ops.keyserver.org/
-      - AUTH_REST_HYDRA_URL=https://auth.rest.hydra.example.com:4445
-      - AUTH_REST_LOG_LEVEL=DEBUG
+      - AUTH_REST_HYDRA_URL=https://hydra.example.com:4445
       - AUTH_REST_API_TOKEN=test_token
       - AUTH_REST_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
       - AUTH_REST_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
+      - AUTH_REST_LOG_LEVEL=DEBUG
     ports:
       - 8070:8070
     entrypoint: ""
     command:  /bin/sh -c "sleep 30 && auth-rest start"
     volumes:
       - ../keys:/etc/keys
+      - ./oidc-config:/etc/oidc-config
     depends_on:
-      - auth.rest.hydra.example.com
-      - third.party.oidc.provider.example.com
+      - hydra.example.com
+      - oidc.provider.example.com
       - mysql
     networks:
       - couchdb_bdd_net
 
-  auth.rest.hydra.example.com:
-    container_name: auth.rest.hydra.example.com
+  hydra.example.com:
+    container_name: hydra.example.com
     image: oryd/hydra:${HYDRA_IMAGE_TAG}
     ports:
-      - 4444:4444 # Public port
-      - 4445:4445 # Admin port
+      - 4444:4444
+      - 4445:4445
     command:  /bin/sh -c "hydra migrate sql --read-from-env --yes; hydra serve all"
     entrypoint: ""
     environment:
-      - DSN=mysql://authresthydra:authresthydra-secret-pw@tcp(mysql:3306)/authresthydra?max_conns=20&max_idle_conns=4
+      - DSN=mysql://hydra:hydra-secret-pw@tcp(mysql:3306)/hydra?max_conns=20&max_idle_conns=4
       - URLS_SELF_ISSUER=https://localhost:4444/
       - URLS_CONSENT=https://localhost:8070/hydra/consent
       - URLS_LOGIN=https://localhost:8070/hydra/login
@@ -72,17 +71,17 @@ services:
     networks:
       - couchdb_bdd_net
 
-  third.party.oidc.provider.example.com:
-    container_name: third.party.oidc.provider.example.com
+  oidc.provider.example.com:
+    container_name: oidc.provider.example.com
     image: oryd/hydra:${HYDRA_IMAGE_TAG}
     ports:
-      - 5555:5555 # Public port
-      - 5556:5556 # Admin port
+      - 5555:5555
+      - 5556:5556
     command: /bin/sh -c "hydra migrate sql --read-from-env --yes; tmp/hydra_configure.sh& hydra serve all"
     entrypoint: ""
     environment:
       - DSN=mysql://thirdpartyoidc:thirdpartyoidc-secret-pw@tcp(mysql:3306)/thirdpartyoidc?max_conns=20&max_idle_conns=4
-      - URLS_SELF_ISSUER=https://third.party.oidc.provider.example.com:5555/
+      - URLS_SELF_ISSUER=https://oidc.provider.example.com:5555/
       - URLS_CONSENT=https://localhost:8099/mock/consent
       - URLS_LOGIN=https://localhost:8099/mock/login
       - SECRETS_SYSTEM=testSecretsSystem
@@ -95,7 +94,7 @@ services:
     restart: unless-stopped
     volumes:
       - ../keys/tls:/etc/tls
-      - ./hydra-config/thirdparty_hydra_configure.sh:/tmp/hydra_configure.sh
+      - ./hydra-config/hydra_configure.sh:/tmp/hydra_configure.sh
     depends_on:
       - mysql
       - mock.login.consent.example.com
@@ -121,7 +120,7 @@ services:
     image: ${MOCK_LOGIN_CONSENT_IMAGE}:latest
     environment:
       - LISTEN_ADDR=:8099
-      - HYDRA_ADMIN_URL=https://third.party.oidc.provider.example.com:5556
+      - HYDRA_ADMIN_URL=https://oidc.provider.example.com:5556
       - TLS_CERT_PATH=/etc/tls/ec-pubCert.pem
       - TLS_KEY_PATH=/etc/tls/ec-key.pem
       - ROOT_CA_CERTS_PATH=/etc/tls/ec-cacert.pem

--- a/test/bdd/fixtures/auth/hydra-config/hydra_configure.sh
+++ b/test/bdd/fixtures/auth/hydra-config/hydra_configure.sh
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-echo "Creating client for auth.rest.example.com..."
+echo "Creating client for hub-auth.example.com..."
 # will use --skip-tls-verify because hydra doesn't trust self-signed certificate
 # remove it when using real certificate
 hydra clients create \
-    --endpoint https://third.party.oidc.provider.example.com:5556 \
+    --endpoint https://oidc.provider.example.com:5556 \
     --id hub-auth \
     --secret hub-auth-secret \
     --grant-types authorization_code,refresh_token \

--- a/test/bdd/fixtures/auth/mysql-config/mysql_config.sql
+++ b/test/bdd/fixtures/auth/mysql-config/mysql_config.sql
@@ -7,21 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 \! echo "Configuring MySQL users...";
 
 /*
-auth rest
+hub auth
 */
-CREATE USER 'authrest'@'%' IDENTIFIED BY 'authrest-secret-pw';
-GRANT ALL PRIVILEGES ON `authrest\_%` . * TO 'authrest'@'%';
+CREATE USER 'hubauth'@'%' IDENTIFIED BY 'hubauth-secret-pw';
+GRANT ALL PRIVILEGES ON `hubauth\_%` . * TO 'hubauth'@'%';
 
 /*
-auth rest hydra
+hydra
 */
-CREATE USER 'authresthydra'@'%' IDENTIFIED BY 'authresthydra-secret-pw';
-CREATE DATABASE authresthydra;
-GRANT ALL PRIVILEGES ON authresthydra.* TO 'authresthydra'@'%';
-
+CREATE USER 'hydra'@'%' IDENTIFIED BY 'hydra-secret-pw';
+CREATE DATABASE hydra;
+GRANT ALL PRIVILEGES ON hydra.* TO 'hydra'@'%';
 
 /*
-third party oidc (hydra)
+oidc provider (hydra)
 */
 CREATE USER 'thirdpartyoidc'@'%' IDENTIFIED BY 'thirdpartyoidc-secret-pw';
 CREATE DATABASE thirdpartyoidc;

--- a/test/bdd/fixtures/auth/oidc-config/providers.yaml
+++ b/test/bdd/fixtures/auth/oidc-config/providers.yaml
@@ -1,0 +1,11 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+providers:
+  mockbank:
+    url: https://oidc.provider.example.com:5555/
+    clientID: hub-auth
+    clientSecret: hub-auth-secret

--- a/test/bdd/fixtures/edv/.env
+++ b/test/bdd/fixtures/edv/.env
@@ -6,7 +6,3 @@
 
 EDV_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/edv-rest
 EDV_REST_IMAGE_TAG=0.1.5-snapshot-cdf0ec8
-
-EDV_DATABASE_TYPE=couchdb
-EDV_DATABASE_URL=admin:password@couchdb.example.com:5984
-EDV_DATABASE_PREFIX=edv

--- a/test/bdd/fixtures/edv/docker-compose.yml
+++ b/test/bdd/fixtures/edv/docker-compose.yml
@@ -12,15 +12,17 @@ services:
     image: ${EDV_REST_IMAGE}:${EDV_REST_IMAGE_TAG}
     environment:
       - EDV_HOST_URL=0.0.0.0:8081
-      - EDV_DATABASE_TYPE=${EDV_DATABASE_TYPE}
-      - EDV_DATABASE_URL=${EDV_DATABASE_URL}
-      - EDV_DATABASE_PREFIX=${EDV_DATABASE_PREFIX}
       - EDV_TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
       - EDV_TLS_KEY_FILE=/etc/tls/ec-key.pem
+      - EDV_DATABASE_TYPE=couchdb
+      - EDV_DATABASE_URL=admin:password@couchdb.example.com:5984
+      - EDV_DATABASE_PREFIX=edv
+      - EDV_LOCALKMS_SECRETS_DATABASE_TYPE=couchdb
+      - EDV_LOCALKMS_SECRETS_DATABASE_URL=admin:password@couchdb.example.com:5984
+      - EDV_LOCALKMS_SECRETS_DATABASE_PREFIX=edv_kms
+      - EDV_EXTENSIONS=ReturnFullDocumentsOnQuery
+      - EDV_DATABASE_TIMEOUT=60
       - EDV_AUTH_ENABLE=true
-      - EDV_LOCALKMS_SECRETS_DATABASE_TYPE=${EDV_DATABASE_TYPE}
-      - EDV_LOCALKMS_SECRETS_DATABASE_URL=${EDV_DATABASE_URL}
-      - EDV_LOCALKMS_SECRETS_DATABASE_PREFIX=${EDV_DATABASE_PREFIX}_kms
       - EDV_LOG_LEVEL=debug
     ports:
       - 8081:8081

--- a/test/bdd/fixtures/kms/docker-compose.yml
+++ b/test/bdd/fixtures/kms/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - KMS_KEY_MANAGER_STORAGE_TYPE=couchdb
       - KMS_KEY_MANAGER_STORAGE_URL=admin:password@couchdb.example.com:5984
       - KMS_KEY_MANAGER_STORAGE_PREFIX=authzkmskm
-      - KMS_HUB_AUTH_URL=https://auth.rest.example.com:8070
+      - KMS_HUB_AUTH_URL=https://hub-auth.example.com:8070
       - KMS_HUB_AUTH_API_TOKEN=test_token
       - KMS_LOG_LEVEL=debug
     ports:

--- a/test/bdd/fixtures/oathkeeper/config/auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/oathkeeper/config/auth-keyserver/config.yaml
@@ -19,7 +19,7 @@ authenticators:
   oauth2_introspection:
     enabled: true
     config:
-      introspection_url: https://auth.rest.hydra.example.com:4445/oauth2/introspect
+      introspection_url: https://hydra.example.com:4445/oauth2/introspect
   noop:
     enabled: true
 

--- a/test/bdd/fixtures/oathkeeper/config/ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/oathkeeper/config/ops-keyserver/config.yaml
@@ -19,7 +19,7 @@ authenticators:
   oauth2_introspection:
     enabled: true
     config:
-      introspection_url: https://auth.rest.hydra.example.com:4445/oauth2/introspect
+      introspection_url: https://hydra.example.com:4445/oauth2/introspect
   noop:
     enabled: true
 

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -9,9 +9,10 @@ go 1.15
 require (
 	github.com/cucumber/godog v0.10.0
 	github.com/fsouza/go-dockerclient v1.6.6
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/rs/xid v1.2.1
+	github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4
 	github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc
 	github.com/trustbloc/edv v0.1.5-0.20201130135645-cdf0ec8eb2a3
 	github.com/trustbloc/hub-auth v0.0.0-20201124144255-48d4c6f991b8 // indirect

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -640,8 +640,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b h1:MhwszjbbQXBheiqs+yBbPTRCTy2GTOW+Pkc6cYFa6Sg=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893 h1:cK1lAVgtoWhUJ2vE8OqiIRsdqTxpM0/nkUqUxQ4TOUc=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20201130232545-14a7f210c893/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb h1:GbE4c+PWz8xZPcZwmKd6jrS8Iwo0j1GJs2UszBbfJTw=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201202081826-f11d5c44d1fb/go.mod h1:QzlBsH2J303U3r8lJ1jq69ackseH+v5/B9hpCFouBqg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/test/bdd/pkg/common/common_steps.go
+++ b/test/bdd/pkg/common/common_steps.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/hub-kms/test/bdd/pkg/bddutil"
 	"github.com/trustbloc/hub-kms/test/bdd/pkg/context"
+	"github.com/trustbloc/hub-kms/test/bdd/pkg/internal/bddutil"
 )
 
 const (

--- a/test/bdd/pkg/healthcheck/healthcheck_steps.go
+++ b/test/bdd/pkg/healthcheck/healthcheck_steps.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/hub-kms/test/bdd/pkg/bddutil"
 	"github.com/trustbloc/hub-kms/test/bdd/pkg/context"
+	"github.com/trustbloc/hub-kms/test/bdd/pkg/internal/bddutil"
 )
 
 const (

--- a/test/bdd/pkg/internal/bddutil/bddutil.go
+++ b/test/bdd/pkg/internal/bddutil/bddutil.go
@@ -8,15 +8,9 @@ package bddutil
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
 	"crypto/tls"
 	"io"
 	"net/http"
-)
-
-const (
-	keySize = sha256.Size
 )
 
 // HTTPDo makes an HTTP request.
@@ -38,16 +32,4 @@ func HTTPDo(method, url string, headers map[string]string, body io.Reader,
 	}
 
 	return httpClient.Do(req)
-}
-
-// GenerateRandomBytes generates an array of 32 random bytes.
-func GenerateRandomBytes() []byte {
-	buf := make([]byte, keySize)
-
-	_, err := rand.Read(buf)
-	if err != nil {
-		panic(err)
-	}
-
-	return buf
 }

--- a/test/bdd/pkg/internal/cryptoutil/cryptoutil.go
+++ b/test/bdd/pkg/internal/cryptoutil/cryptoutil.go
@@ -1,0 +1,67 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cryptoutil
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/teserakt-io/golang-ed25519/extra25519"
+)
+
+const (
+	defaultKeySize     = sha256.Size
+	curve25519KeySize  = 32
+	cryptoBoxNonceSize = 24
+)
+
+// GenerateKey generates a key of 32 bytes long.
+func GenerateKey() []byte {
+	return generateRandomBytes(defaultKeySize)
+}
+
+// GenerateNonceForCryptoBox generates nonce used by CryptoBox encryption.
+func GenerateNonceForCryptoBox() []byte {
+	return generateRandomBytes(cryptoBoxNonceSize)
+}
+
+// PublicEd25519toCurve25519 takes an Ed25519 public key and provides the corresponding Curve25519 public key.
+func PublicEd25519toCurve25519(pub []byte) ([]byte, error) {
+	if len(pub) == 0 {
+		return nil, errors.New("public key is nil")
+	}
+
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%d-byte key size is invalid", len(pub))
+	}
+
+	pkOut := new([curve25519KeySize]byte)
+	pKIn := new([curve25519KeySize]byte)
+	copy(pKIn[:], pub)
+
+	success := extra25519.PublicKeyToCurve25519(pkOut, pKIn)
+	if !success {
+		return nil, errors.New("error converting public key")
+	}
+
+	return pkOut[:], nil
+}
+
+// GenerateRandomBytes generates an array of n random bytes.
+func generateRandomBytes(n uint32) []byte {
+	buf := make([]byte, n)
+
+	_, err := rand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+
+	return buf
+}

--- a/test/bdd/pkg/keystore/keystore_steps.go
+++ b/test/bdd/pkg/keystore/keystore_steps.go
@@ -21,8 +21,8 @@ import (
 	authbddctx "github.com/trustbloc/hub-auth/test/bdd/pkg/context"
 	authlogin "github.com/trustbloc/hub-auth/test/bdd/pkg/login"
 
-	"github.com/trustbloc/hub-kms/test/bdd/pkg/bddutil"
 	"github.com/trustbloc/hub-kms/test/bdd/pkg/context"
+	"github.com/trustbloc/hub-kms/test/bdd/pkg/internal/bddutil"
 )
 
 const (

--- a/test/bdd/pkg/kms/kms_crypto_box_steps.go
+++ b/test/bdd/pkg/kms/kms_crypto_box_steps.go
@@ -1,0 +1,146 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kms
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/trustbloc/hub-kms/test/bdd/pkg/internal/cryptoutil"
+)
+
+func (s *Steps) makeEasyPayloadReq(userName, endpoint, payload, recipient string) error { //nolint:funlen // ignore
+	u := s.users[userName]
+
+	recipientPubKey := u.recipientPubKeys[recipient]
+
+	recPubCurve25519, err := cryptoutil.PublicEd25519toCurve25519(recipientPubKey.rawBytes)
+	if err != nil {
+		return err
+	}
+
+	nonce := cryptoutil.GenerateNonceForCryptoBox()
+	encodedNonce := base64.URLEncoding.EncodeToString(nonce)
+
+	u.requestValues = map[string]string{"nonce": encodedNonce}
+
+	r := &easyReq{
+		Payload:  base64.URLEncoding.EncodeToString([]byte(payload)),
+		Nonce:    encodedNonce,
+		TheirPub: base64.URLEncoding.EncodeToString(recPubCurve25519),
+	}
+
+	request, err := u.preparePostRequest(r, endpoint)
+	if err != nil {
+		return err
+	}
+
+	err = u.SetCapabilityInvocation(request, actionEasy)
+	if err != nil {
+		return fmt.Errorf("user failed to set zcap: %w", err)
+	}
+
+	err = u.Sign(request)
+	if err != nil {
+		return fmt.Errorf("user failed to sign request: %w", err)
+	}
+
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+
+	defer func() {
+		closeErr := response.Body.Close()
+		if closeErr != nil {
+			s.logger.Errorf("Failed to close response body: %s\n", closeErr.Error())
+		}
+	}()
+
+	var easyResponse easyResp
+
+	if respErr := u.processResponse(&easyResponse, response); respErr != nil {
+		return respErr
+	}
+
+	cipherText, err := base64.URLEncoding.DecodeString(easyResponse.CipherText)
+	if err != nil {
+		return err
+	}
+
+	u.response.body = map[string]string{
+		"cipherText": string(cipherText),
+	}
+
+	return nil
+}
+
+func (s *Steps) makeEasyOpenReq(userName, endpoint, tag, sender string) error { //nolint:funlen // ignoreg
+	u := s.users[userName]
+
+	cipherText := s.users[sender].response.body[tag]
+	nonce := s.users[sender].requestValues["nonce"]
+	myPub := s.users[sender].recipientPubKeys[userName].rawBytes
+
+	theirPub := u.recipientPubKeys[sender].rawBytes
+
+	theirPubCurve25519, err := cryptoutil.PublicEd25519toCurve25519(theirPub)
+	if err != nil {
+		return err
+	}
+
+	r := &easyOpenReq{
+		CipherText: base64.URLEncoding.EncodeToString([]byte(cipherText)),
+		Nonce:      nonce,
+		TheirPub:   base64.URLEncoding.EncodeToString(theirPubCurve25519),
+		MyPub:      base64.URLEncoding.EncodeToString(myPub),
+	}
+
+	request, err := u.preparePostRequest(r, endpoint)
+	if err != nil {
+		return err
+	}
+
+	err = u.SetCapabilityInvocation(request, actionEasyOpen)
+	if err != nil {
+		return fmt.Errorf("user failed to set zcap: %w", err)
+	}
+
+	err = u.Sign(request)
+	if err != nil {
+		return fmt.Errorf("user failed to sign request: %w", err)
+	}
+
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+
+	defer func() {
+		closeErr := response.Body.Close()
+		if closeErr != nil {
+			s.logger.Errorf("Failed to close response body: %s\n", closeErr.Error())
+		}
+	}()
+
+	var easyOpenResponse easyOpenResp
+
+	if respErr := u.processResponse(&easyOpenResponse, response); respErr != nil {
+		return respErr
+	}
+
+	plainText, err := base64.URLEncoding.DecodeString(easyOpenResponse.PlainText)
+	if err != nil {
+		return err
+	}
+
+	u.response.body = map[string]string{
+		"plainText": string(plainText),
+	}
+
+	return nil
+}

--- a/test/bdd/pkg/kms/models.go
+++ b/test/bdd/pkg/kms/models.go
@@ -66,11 +66,11 @@ type verifyMACReq struct {
 }
 
 type wrapReq struct {
-	CEK             string    `json:"cek,omitempty"`
-	APU             string    `json:"apu,omitempty"`
-	APV             string    `json:"apv,omitempty"`
-	RecipientPubKey publicKey `json:"recPubKey,omitempty"`
-	SenderKID       string    `json:"senderKID,omitempty"`
+	CEK             string       `json:"cek,omitempty"`
+	APU             string       `json:"apu,omitempty"`
+	APV             string       `json:"apv,omitempty"`
+	RecipientPubKey publicKeyReq `json:"recPubKey,omitempty"`
+	SenderKID       string       `json:"senderKID,omitempty"`
 }
 
 type wrapResp struct {
@@ -78,12 +78,12 @@ type wrapResp struct {
 }
 
 type recipientWrappedKey struct {
-	KID          string    `json:"kid,omitempty"`
-	EncryptedCEK string    `json:"encryptedCEK,omitempty"`
-	EPK          publicKey `json:"epk,omitempty"`
-	Alg          string    `json:"alg,omitempty"`
-	APU          string    `json:"apu,omitempty"`
-	APV          string    `json:"apv,omitempty"`
+	KID          string       `json:"kid,omitempty"`
+	EncryptedCEK string       `json:"encryptedCEK,omitempty"`
+	EPK          publicKeyReq `json:"epk,omitempty"`
+	Alg          string       `json:"alg,omitempty"`
+	APU          string       `json:"apu,omitempty"`
+	APV          string       `json:"apv,omitempty"`
 }
 
 type unwrapReq struct {
@@ -95,7 +95,7 @@ type unwrapResp struct {
 	Key string `json:"key,omitempty"`
 }
 
-type publicKey struct {
+type publicKeyReq struct {
 	KID   string `json:"kid,omitempty"`
 	X     string `json:"x,omitempty"`
 	Y     string `json:"y,omitempty"`
@@ -103,7 +103,7 @@ type publicKey struct {
 	Type  string `json:"type,omitempty"`
 }
 
-type publicKeyWithBytesXY struct {
+type publicKey struct {
 	KID   string `json:"kid,omitempty"`
 	X     []byte `json:"x,omitempty"`
 	Y     []byte `json:"y,omitempty"`
@@ -117,4 +117,25 @@ type setSecretRequest struct {
 
 type errorResponse struct {
 	Message string `json:"errMessage,omitempty"`
+}
+
+type easyReq struct {
+	Payload  string `json:"payload"`
+	Nonce    string `json:"nonce"`
+	TheirPub string `json:"theirPub"`
+}
+
+type easyResp struct {
+	CipherText string `json:"cipherText"`
+}
+
+type easyOpenReq struct {
+	CipherText string `json:"cipherText"`
+	Nonce      string `json:"nonce"`
+	TheirPub   string `json:"theirPub"`
+	MyPub      string `json:"myPub"`
+}
+
+type easyOpenResp struct {
+	PlainText string `json:"plainText"`
 }

--- a/test/bdd/pkg/kms/user.go
+++ b/test/bdd/pkg/kms/user.go
@@ -36,8 +36,9 @@ type user struct {
 	subject     string
 	secretShare []byte
 
-	recipientPubKeys map[string]publicKeyWithBytesXY
+	recipientPubKeys map[string]*publicKeyData
 	response         *response
+	requestValues    map[string]string
 
 	signer        signer
 	authKMS       kms.KeyManager
@@ -45,6 +46,11 @@ type user struct {
 	edvCapability *zcapld.Capability
 	kmsCapability *zcapld.Capability
 	accessToken   string
+}
+
+type publicKeyData struct {
+	rawBytes  []byte
+	parsedKey *publicKey
 }
 
 type response struct {

--- a/test/bdd/pkg/kms/zcap.go
+++ b/test/bdd/pkg/kms/zcap.go
@@ -32,6 +32,8 @@ const (
 	actionEncrypt         = "encrypt"
 	actionDecrypt         = "decrypt"
 	actionStoreCapability = "updateEDVCapability"
+	actionEasy            = "easy"
+	actionEasyOpen        = "easyOpen"
 )
 
 type signer interface {


### PR DESCRIPTION
This PR also fixes missing `actionEasy`, `actionEasyOpen` and `actionSealOpen` in the list of supported ZCAP actions.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>