### PR TITLE
fix: remove CORS

### DIFF
--- a/cmd/kms-rest/startcmd/start.go
+++ b/cmd/kms-rest/startcmd/start.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
 	ariesstorage "github.com/hyperledger/aries-framework-go/pkg/storage"
 	ariesmemstorage "github.com/hyperledger/aries-framework-go/pkg/storage/mem"
-	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/edge-core/pkg/restapi/logspec"
@@ -580,7 +579,7 @@ func startKmsService(params *kmsRestParameters, srv Server) error {
 		params.hostURL,
 		params.tlsServeParams.certPath,
 		params.tlsServeParams.keyPath,
-		constructCORSHandler(router))
+		router)
 }
 
 func setLogLevel(level string, srv Server) {
@@ -676,13 +675,4 @@ func prepareKMSStorageProvider(params *storageParameters) (ariesstorage.Provider
 	default:
 		return nil, errors.New("KMS storage not set to a valid type")
 	}
-}
-
-func constructCORSHandler(handler http.Handler) http.Handler {
-	return cors.New(
-		cors.Options{
-			AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodOptions},
-			AllowedHeaders: []string{"*"},
-		},
-	).Handler(handler)
 }


### PR DESCRIPTION
unblocks: https://github.com/trustbloc/edge-agent/pull/578

Reason: the service will always be behind a proxy in order to protect the `POST /kms/keystores` operation at minimum. Leaving CORS enabled results in the final response to the client containing two values for Access-Control-Allow-Origin, which is invalid:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed.

Signed-off-by: George Aristy <george.aristy@securekey.com>