### PR TITLE
feat: OpenAPI spec/demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage.out
 *.log
 
 test/bdd/fixtures/keys
+test/bdd/fixtures/openapi-demo/specs/

--- a/cmd/kms-rest/main.go
+++ b/cmd/kms-rest/main.go
@@ -4,6 +4,19 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package kms-rest KMS API.
+//
+//     Schemes: http
+//     Version: 0.1.0
+//     License: SPDX-License-Identifier: Apache-2.0
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+// swagger:meta
 package main
 
 import (

--- a/cmd/kms-rest/startcmd/start_test.go
+++ b/cmd/kms-rest/startcmd/start_test.go
@@ -333,6 +333,32 @@ func TestStartCmdWithHubAuthURLParam(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestStartCmdWithEnableCORSParam(t *testing.T) {
+	t.Run("Success with CORS enabled", func(t *testing.T) {
+		startCmd := GetStartCmd(&mockServer{})
+
+		args := requiredArgs()
+		args = append(args, "--"+enableCORSFlagName, "true")
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("Fail with invalid enable-cors param", func(t *testing.T) {
+		startCmd := GetStartCmd(&mockServer{})
+
+		args := requiredArgs()
+		args = append(args, "--"+enableCORSFlagName, "invalid")
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+	})
+}
+
 func TestStartKMSService(t *testing.T) {
 	const invalidStorageOption = "invalid"
 

--- a/pkg/restapi/kms/operation/models.go
+++ b/pkg/restapi/kms/operation/models.go
@@ -8,8 +8,7 @@ package operation
 
 import "encoding/json"
 
-// CreateKeystoreReq create key store request.
-type CreateKeystoreReq struct {
+type createKeystoreReq struct {
 	Controller string `json:"controller"`
 	VaultID    string `json:"vaultID,omitempty"`
 }
@@ -143,4 +142,8 @@ type sealOpenReq struct {
 
 type sealOpenResp struct {
 	PlainText string `json:"plainText"`
+}
+
+type errorResp struct {
+	Message string `json:"errMessage,omitempty"`
 }

--- a/pkg/restapi/kms/operation/openapi.go
+++ b/pkg/restapi/kms/operation/openapi.go
@@ -1,0 +1,318 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+// createKeystoreReq model
+//
+// swagger:parameters createKeystoreReq
+type createKeystoreReqSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	// required: true
+	CreateKeystoreReq createKeystoreReq
+}
+
+// createKeystoreResp model
+//
+// swagger:response createKeystoreResp
+type createKeystoreRespSpec struct { //nolint:unused,deadcode // spec
+	Location string
+}
+
+// updateCapabilityReq model
+//
+// swagger:parameters updateCapabilityReq
+type updateCapabilityReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: body
+	// required: true
+	UpdateCapabilityReq UpdateCapabilityReq
+}
+
+// createKeyReq model
+//
+// swagger:parameters createKeyReq
+type createKeyReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: body
+	// required: true
+	CreateKeyReq createKeyReq
+}
+
+// createKeyResp model
+//
+// swagger:response createKeyResp
+type createKeyRespSpec struct { //nolint:unused,deadcode // spec
+	Location string
+	// in: body
+	CreateKeyResp createKeyResp
+}
+
+// exportKeyReq model
+//
+// swagger:parameters exportKeyReq
+type exportKeyReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+}
+
+// exportKeyResp model
+//
+// swagger:response exportKeyResp
+type exportKeyRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	ExportKeyResp exportKeyResp
+}
+
+// signReq model
+//
+// swagger:parameters signReq
+type signReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	SignReq signReq
+}
+
+// signResp model
+//
+// swagger:response signResp
+type signRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	SignResp signResp
+}
+
+// verifyReq model
+//
+// swagger:parameters verifyReq
+type verifyReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	VerifyReq verifyReq
+}
+
+// encryptReq model
+//
+// swagger:parameters encryptReq
+type encryptReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	EncryptReq encryptReq
+}
+
+// encryptResp model
+//
+// swagger:parameters encryptResp
+type encryptRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	EncryptResp encryptResp
+}
+
+// decryptReq model
+//
+// swagger:parameters decryptReq
+type decryptReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	DecryptReq decryptReq
+}
+
+// decryptResp model
+//
+// swagger:parameters decryptResp
+type decryptRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	DecryptResp decryptResp
+}
+
+// computeMACReq model
+//
+// swagger:parameters computeMACReq
+type computeMACReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	ComputeMACReq computeMACReq
+}
+
+// computeMACResp model
+//
+// swagger:parameters computeMACResp
+type computeMACRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	ComputeMACResp computeMACResp
+}
+
+// verifyMACReq model
+//
+// swagger:parameters verifyMACReq
+type verifyMACReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	VerifyMACReq verifyMACReq
+}
+
+// wrapReq model
+//
+// swagger:parameters wrapReq
+type wrapReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: body
+	// required: true
+	WrapReq wrapReq
+}
+
+// wrapResp model
+//
+// swagger:parameters wrapResp
+type wrapRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	WrapResp wrapResp
+}
+
+// unwrapReq model
+//
+// swagger:parameters unwrapReq
+type unwrapReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	UnwrapReq unwrapReq
+}
+
+// unwrapResp model
+//
+// swagger:parameters unwrapResp
+type unwrapRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	UnwrapResp unwrapResp
+}
+
+// easyReq model
+//
+// swagger:parameters easyReq
+type easyReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: path
+	// required: true
+	KeyID string `json:"keyID"`
+	// in: body
+	// required: true
+	EasyReq easyReq
+}
+
+// easyResp model
+//
+// swagger:parameters easyResp
+type easyRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	EasyResp easyResp
+}
+
+// easyOpenReq model
+//
+// swagger:parameters easyOpenReq
+type easyOpenReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: body
+	// required: true
+	EasyOpenReq easyOpenReq
+}
+
+// easyOpenResp model
+//
+// swagger:parameters easyOpenResp
+type easyOpenRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	EasyOpenResp easyOpenResp
+}
+
+// sealOpenReq model
+//
+// swagger:parameters sealOpenReq
+type sealOpenReqSpec struct { //nolint:unused,deadcode // spec
+	// in: path
+	// required: true
+	KeystoreID string `json:"keystoreID"`
+	// in: body
+	// required: true
+	SealOpenReq sealOpenReq
+}
+
+// sealOpenResp model
+//
+// swagger:parameters sealOpenResp
+type sealOpenRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	SealOpenResp sealOpenResp
+}
+
+// errorResp model
+//
+// swagger:response errorResp
+type errorRespSpec struct { //nolint:unused,deadcode // spec
+	// in: body
+	ErrorResp errorResp
+}
+
+// emptyRes model
+//
+// swagger:response emptyRes
+type emptyRes struct { //nolint:unused,deadcode // spec
+}

--- a/pkg/restapi/kms/operation/operations.go
+++ b/pkg/restapi/kms/operation/operations.go
@@ -187,10 +187,17 @@ func (o *Operation) GetRESTHandlers() []Handler {
 	}
 }
 
+// swagger:route POST /kms/keystores keystore createKeystoreReq
+//
+// Creates a new Keystore.
+//
+// Responses:
+//        201: createKeystoreResp
+//    default: errorResp
 func (o *Operation) createKeystoreHandler(rw http.ResponseWriter, req *http.Request) {
 	o.logger.Debugf("handling request: %s", req.URL.String())
 
-	var request CreateKeystoreReq
+	var request createKeystoreReq
 	if ok := o.parseRequest(&request, rw, req); !ok {
 		return
 	}
@@ -243,6 +250,13 @@ func (o *Operation) createKeystoreHandler(rw http.ResponseWriter, req *http.Requ
 	o.logger.Debugf("finished handling request - keystore: %s", resource)
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/keys kms createKeyReq
+//
+// Creates a new key.
+//
+// Responses:
+//        201: createKeyResp
+//    default: errorResp
 func (o *Operation) createKeyHandler(rw http.ResponseWriter, req *http.Request) {
 	o.logger.Debugf("handling request: %s", req.URL.String())
 
@@ -281,6 +295,13 @@ func (o *Operation) createKeyHandler(rw http.ResponseWriter, req *http.Request) 
 	o.logger.Debugf("finished handling request")
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/capability zcap updateCapabilityReq
+//
+// Updates ZCAP capabilities.
+//
+// Responses:
+//        201: emptyRes
+//    default: errorResp
 func (o *Operation) updateCapabilityHandler(rw http.ResponseWriter, req *http.Request) {
 	var request UpdateCapabilityReq
 	if ok := o.parseRequest(&request, rw, req); !ok {
@@ -314,6 +335,13 @@ func (o *Operation) updateCapabilityHandler(rw http.ResponseWriter, req *http.Re
 	rw.WriteHeader(http.StatusOK)
 }
 
+// swagger:route GET /kms/keystores/{keystoreID}/keys/{keyID} kms exportKeyReq
+//
+// Exports a public key.
+//
+// Responses:
+//        200: exportKeyResp
+//    default: errorResp
 func (o *Operation) exportKeyHandler(rw http.ResponseWriter, req *http.Request) {
 	o.logger.Debugf(prepareDebugOutputForRequest(req, o.logger))
 
@@ -339,8 +367,14 @@ func (o *Operation) exportKeyHandler(rw http.ResponseWriter, req *http.Request) 
 	})
 }
 
-//nolint:dupl // better readability
-func (o *Operation) signHandler(rw http.ResponseWriter, req *http.Request) {
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/sign kms signReq
+//
+// Signs a message.
+//
+// Responses:
+//        200: signResp
+//    default: errorResp
+func (o *Operation) signHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // better readability
 	o.logger.Debugf("handling request: %s", req.URL.String())
 
 	kmsService, err := o.kmsServiceCreator(req)
@@ -379,8 +413,14 @@ func (o *Operation) signHandler(rw http.ResponseWriter, req *http.Request) {
 	o.logger.Debugf("finished handling request: %s", req.URL.String())
 }
 
-//nolint:dupl // better readability
-func (o *Operation) verifyHandler(rw http.ResponseWriter, req *http.Request) {
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/verify kms verifyReq
+//
+// Verifies a signature for the message.
+//
+// Responses:
+//        200: emptyRes
+//    default: errorResp
+func (o *Operation) verifyHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // better readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, createKMSServiceFailure, err)
@@ -420,6 +460,13 @@ func (o *Operation) verifyHandler(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/encrypt kms encryptReq
+//
+// Encrypts a message.
+//
+// Responses:
+//        200: encryptResp
+//    default: errorResp
 func (o *Operation) encryptHandler(rw http.ResponseWriter, req *http.Request) {
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
@@ -463,6 +510,13 @@ func (o *Operation) encryptHandler(rw http.ResponseWriter, req *http.Request) {
 	})
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/decrypt kms decryptReq
+//
+// Decrypts a cipher.
+//
+// Responses:
+//        200: decryptResp
+//    default: errorResp
 func (o *Operation) decryptHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
@@ -512,8 +566,14 @@ func (o *Operation) decryptHandler(rw http.ResponseWriter, req *http.Request) { 
 	})
 }
 
-//nolint:dupl // better readability
-func (o *Operation) computeMACHandler(rw http.ResponseWriter, req *http.Request) {
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/computemac kms computeMACReq
+//
+// Computes MAC for data.
+//
+// Responses:
+//        200: computeMACResp
+//    default: errorResp
+func (o *Operation) computeMACHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // better readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, createKMSServiceFailure, err)
@@ -548,8 +608,14 @@ func (o *Operation) computeMACHandler(rw http.ResponseWriter, req *http.Request)
 	})
 }
 
-//nolint:dupl // better readability
-func (o *Operation) verifyMACHandler(rw http.ResponseWriter, req *http.Request) {
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/verifymac kms verifyMACReq
+//
+// Verifies MAC for data.
+//
+// Responses:
+//        200: emptyRes
+//    default: errorResp
+func (o *Operation) verifyMACHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // better readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, createKMSServiceFailure, err)
@@ -589,6 +655,13 @@ func (o *Operation) verifyMACHandler(rw http.ResponseWriter, req *http.Request) 
 	rw.WriteHeader(http.StatusOK)
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/wrap kms wrapReq
+//
+// Wraps CEK for the recipient.
+//
+// Responses:
+//        200: wrapResp
+//    default: errorResp
 func (o *Operation) wrapHandler(rw http.ResponseWriter, req *http.Request) {
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
@@ -649,8 +722,14 @@ func (o *Operation) wrapHandler(rw http.ResponseWriter, req *http.Request) {
 	}})
 }
 
-//nolint:funlen // readability
-func (o *Operation) unwrapHandler(rw http.ResponseWriter, req *http.Request) {
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/unwrap kms unwrapReq
+//
+// Unwraps a key.
+//
+// Responses:
+//        200: unwrapResp
+//    default: errorResp
+func (o *Operation) unwrapHandler(rw http.ResponseWriter, req *http.Request) { //nolint:funlen // readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, createKMSServiceFailure, err)
@@ -750,16 +829,12 @@ func prepareDebugOutputForRequest(
 	return string(dump)
 }
 
-type errorResponse struct {
-	Message string `json:"errMessage,omitempty"`
-}
-
 func (o *Operation) writeErrorResponse(rw http.ResponseWriter, status int, messageFormat string, err error) {
 	o.logger.Errorf(messageFormat, err)
 
 	rw.WriteHeader(status)
 
-	e := json.NewEncoder(rw).Encode(errorResponse{
+	e := json.NewEncoder(rw).Encode(errorResp{
 		Message: fmt.Sprintf(messageFormat, kms.UserErrorMessage(err)),
 	})
 

--- a/pkg/restapi/kms/operation/operations_cryptobox.go
+++ b/pkg/restapi/kms/operation/operations_cryptobox.go
@@ -13,6 +13,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// swagger:route POST /kms/keystores/{keystoreID}/keys/{keyID}/easy crypto-box easyReq
+//
+// Encrypts (anonymously) a payload.
+//
+// Responses:
+//        200: easyResp
+//    default: errorResp
 func (o *Operation) easyHandler(rw http.ResponseWriter, req *http.Request) { //nolint:dupl // readability
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
@@ -62,6 +69,13 @@ func (o *Operation) easyHandler(rw http.ResponseWriter, req *http.Request) { //n
 	})
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/easyopen crypto-box easyOpenReq
+//
+// Decrypts (easy open) a payload.
+//
+// Responses:
+//        200: easyOpenResp
+//    default: errorResp
 func (o *Operation) easyOpenHandler(rw http.ResponseWriter, req *http.Request) {
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {
@@ -117,6 +131,13 @@ func (o *Operation) easyOpenHandler(rw http.ResponseWriter, req *http.Request) {
 	})
 }
 
+// swagger:route POST /kms/keystores/{keystoreID}/sealopen crypto-box sealOpenReq
+//
+// Decrypts ("seal open") a payload.
+//
+// Responses:
+//        200: sealOpenResp
+//    default: errorResp
 func (o *Operation) sealOpenHandler(rw http.ResponseWriter, req *http.Request) {
 	kmsService, err := o.kmsServiceCreator(req)
 	if err != nil {

--- a/scripts/generate-openapi-demo-specs.sh
+++ b/scripts/generate-openapi-demo-specs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+BASE_SPEC_LOC="${SPEC_PATH}/openAPI.yml"
+DEMO_PATH="${OPENAPI_DEMO_PATH}"
+IMAGE="${DOCKER_IMAGE:-quay.io/goswagger/swagger}"
+IMAGE_VERSION="${DOCKER_IMAGE_VERSION:-latest}"
+OUTPUT_PATH="$DEMO_PATH/specs"
+
+if [ ! -f "$BASE_SPEC_LOC" ]; then
+    echo "'$BASE_SPEC_LOC' doesn't exists"
+    exit 1
+fi
+
+set -o allexport
+[[ -f $DEMO_PATH/.env ]] && source $DEMO_PATH/.env
+set +o allexport
+
+mkdir -p $OUTPUT_PATH
+
+# generate sub specs using .env entries and mix them using 'swagger mixin'
+while IFS='=' read -r name value ; do
+  if [[ $name == *'_API_HOST' ]]; then
+    result="${!name}"
+    echo "host: $result" > $OUTPUT_PATH/$result.yml
+    command="mixin $BASE_SPEC_LOC $OUTPUT_PATH/${result}.yml -o $OUTPUT_PATH/openapi-${result}.yml --format yaml"
+    docker run --rm -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $command
+    rm -rf $OUTPUT_PATH/$result.yml
+  fi
+done < <(env)

--- a/scripts/generate-openapi-spec.sh
+++ b/scripts/generate-openapi-spec.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+SPEC_LOC="${SPEC_LOC}"
+SPEC_META="${SPEC_META:-cmd/kms-rest}"
+OUTPUT="$PWD/$SPEC_LOC/openAPI.yml"
+IMAGE="${DOCKER_IMAGE:-quay.io/goswagger/swagger}"
+IMAGE_VERSION="${DOCKER_IMAGE_VERSION:-latest}"
+
+cd $SPEC_META
+
+# generate and validate commands
+GENERATE_COMMAND="generate spec main.go -o $OUTPUT"
+VALIDATE_COMMAND="validate $OUTPUT"
+
+echo "Generating OpenAPI spec"
+docker run --rm -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $GENERATE_COMMAND
+
+echo "Validating generated spec"
+docker run --rm -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $VALIDATE_COMMAND

--- a/scripts/run-openapi-demo.sh
+++ b/scripts/run-openapi-demo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+DEMO_COMPOSE_OP="${DEMO_COMPOSE_OP:-up --force-recreate}"
+
+FIXTURES_ABS_PATH="$PWD/$FIXTURES_PATH"
+
+declare -a features=(
+                "couchdb"
+                "openapi-demo"
+               )
+
+for feature in "${features[@]}"
+do
+   cd "$FIXTURES_ABS_PATH/$feature"
+   docker-compose -f docker-compose.yml ${DEMO_COMPOSE_OP} -d
+done

--- a/test/bdd/fixtures/openapi-demo/.env
+++ b/test/bdd/fixtures/openapi-demo/.env
@@ -1,0 +1,10 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Open Demo API hosts
+OPEN_API_HOST=localhost:8080
+
+KMS_REST_IMAGE=docker.pkg.github.com/trustbloc/hub-kms/kms-rest

--- a/test/bdd/fixtures/openapi-demo/docker-compose.yml
+++ b/test/bdd/fixtures/openapi-demo/docker-compose.yml
@@ -1,0 +1,53 @@
+#
+# Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+
+  openapi.demo.com:
+    container_name: openapi.demo.com
+    image: swaggerapi/swagger-ui
+    environment:
+      - SWAGGER_JSON=/specs/openapi-${OPEN_API_HOST}.yml
+      - BASE_URL=/openapi
+    ports:
+      - 8089:8080
+    volumes:
+      - ./specs:/specs
+    networks:
+      - couchdb_bdd_net
+
+  kms.example.com:
+    container_name: kms.example.com
+    image: ${KMS_REST_IMAGE}:latest
+    environment:
+      - KMS_HOST_URL=0.0.0.0:8080
+      - KMS_DATABASE_TYPE=couchdb
+      - KMS_DATABASE_URL=admin:password@couchdb.example.com:5984
+      - KMS_DATABASE_PREFIX=keystore
+      - KMS_PRIMARY_KEY_DATABASE_TYPE=couchdb
+      - KMS_PRIMARY_KEY_DATABASE_URL=admin:password@couchdb.example.com:5984
+      - KMS_PRIMARY_KEY_DATABASE_PREFIX=kmspk
+      - KMS_LOCAL_KMS_DATABASE_TYPE=couchdb
+      - KMS_LOCAL_KMS_DATABASE_URL=admin:password@couchdb.example.com:5984
+      - KMS_LOCAL_KMS_DATABASE_PREFIX=kmslocal
+      - KMS_KEY_MANAGER_STORAGE_TYPE=couchdb
+      - KMS_KEY_MANAGER_STORAGE_URL=admin:password@couchdb.example.com:5984
+      - KMS_KEY_MANAGER_STORAGE_PREFIX=kmskm
+      - KMS_ZCAP_ENABLE=false
+      - KMS_CORS_ENABLE=true
+      - KMS_LOG_LEVEL=debug
+    ports:
+      - 8080:8080
+    entrypoint: ""
+    # TODO add retry for couchdb
+    command: /bin/sh -c "sleep 5;kms-rest start"
+    networks:
+      - couchdb_bdd_net
+
+networks:
+  couchdb_bdd_net:
+    external: true


### PR DESCRIPTION
This PR also adds back CORS that is needed for OpenAPI demo. By default it's **disabled**, and can be enabled by setting `KMS_CORS_ENABLE` to `true`.

Closes #54

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>