### PR TITLE
perf: add support for OpenTelemetry with Jaeger collector

### DIFF
--- a/cmd/kms-rest/go.mod
+++ b/cmd/kms-rest/go.mod
@@ -16,7 +16,12 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 	golang.org/x/net v0.0.0-20201207224615-747e23833adb // indirect
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
+	google.golang.org/api v0.36.0 // indirect
 )
 
 replace (

--- a/cmd/kms-rest/go.sum
+++ b/cmd/kms-rest/go.sum
@@ -16,6 +16,7 @@ cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKV
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
+cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -69,6 +70,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/sketches-go v0.0.1 h1:RtG+76WKgZuz6FIaGsjoPePmadDBkuD/KC6+ZWu78b8=
+github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -104,6 +107,8 @@ github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5/go.mod h1
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
+github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apple/foundationdb/bindings/go v0.0.0-20190411004307-cd5c9d91fad2/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -122,6 +127,7 @@ github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.35.1/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.35.7/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
+github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -336,6 +342,8 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
+github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -352,13 +360,17 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-metrics-stackdriver v0.2.0/go.mod h1:KLcPyp3dWJAFD+yHisGlJSZktIsTjb50eB72U2YZ9K0=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190309163659-77426154d546/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -367,6 +379,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/tink/go v1.4.0-rc2.0.20200807212851-52ae9c6679b2 h1:8Xm0rj8hf5lNSxE1BdKebg44pQoWomTLuxyG3MPGgO0=
 github.com/google/tink/go v1.4.0-rc2.0.20200807212851-52ae9c6679b2/go.mod h1:OdW+ACSIXwGiPOWJiRTdoKzStsnqo8ZOsTzchWLy2DY=
@@ -534,6 +547,7 @@ github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-2
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5 h1:lcnsNy983eXWEhi3uWFq/RV4ut6umrMQj/V7FtZ175A=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5/go.mod h1:6h4vLybbbz82KKsU5Qi15+SOT76U6jbd1//QL5ywQIM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -839,6 +853,7 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -899,6 +914,13 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opentelemetry.io/otel v0.15.0 h1:CZFy2lPhxd4HlhZnYK8gRyDotksO3Ip9rBweY1vVYJw=
+go.opentelemetry.io/otel v0.15.0/go.mod h1:e4GKElweB8W2gWUqbghw0B8t5MCTccc9212eNHnOHwA=
+go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0 h1:OZY+lMaUJiJ6ls1dDtqKhSPJWEVNytLuRUrzuR852jc=
+go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0/go.mod h1:4DeFMzRzr2l5o/Lzh4GfOYEH+mnf7ZrEGDzzJEP6ta8=
+go.opentelemetry.io/otel/sdk v0.15.0 h1:Hf2dl1Ad9Hn03qjcAuAq51GP5Pv1SV5puIkS2nRhdd8=
+go.opentelemetry.io/otel/sdk v0.15.0/go.mod h1:Qudkwgq81OcA9GYVlbyZ62wkLieeS1eWxIL0ufxgwoc=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -1013,6 +1035,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201009032441-dbdefad45b89 h1:1GKfLldebiSdhTlt3nalwrb7L40Tixr/0IH+kSbRgmk=
 golang.org/x/net v0.0.0-20201009032441-dbdefad45b89/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201207224615-747e23833adb h1:xj2oMIbduz83x7tzglytWT7spn6rP+9hvKjTpro6/pM=
@@ -1027,6 +1051,7 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1034,7 +1059,11 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1096,6 +1125,8 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1103,6 +1134,7 @@ golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5f
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1164,6 +1196,8 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -1193,7 +1227,11 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
+google.golang.org/api v0.32.0 h1:Le77IccnTqEa8ryp9wIpX5W3zYm7Gf9LhOp9PHcwFts=
 google.golang.org/api v0.32.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
+google.golang.org/api v0.35.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
+google.golang.org/api v0.36.0 h1:l2Nfbl2GPXdWorv+dT2XfinX2jOOw4zv1VhLstx+6rE=
+google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34qYtE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1202,6 +1240,7 @@ google.golang.org/appengine v1.6.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181219182458-5a97ab628bfb/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1240,6 +1279,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -1261,6 +1302,7 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/cmd/kms-rest/startcmd/start_prepare_kms.go
+++ b/cmd/kms-rest/startcmd/start_prepare_kms.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package startcmd
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"strings"
@@ -64,10 +65,10 @@ func prepareKMSServiceCreator(keystoreSrv keystore.Service, cryptoSrv cryptoapi.
 
 func prepareStorageResolver(keystoreSrv keystore.Service, cryptoSrv cryptoapi.Crypto, signer edv.HeaderSigner,
 	cacheProvider ariesstorage.Provider, storageParams *storageParameters,
-	tlsConfig *tls.Config) func(string) (ariesstorage.Provider, error) {
+	tlsConfig *tls.Config) func(ctx context.Context, keystoreID string) (ariesstorage.Provider, error) {
 	switch {
 	case strings.EqualFold(storageParams.storageType, storageTypeEDVOption):
-		return func(keystoreID string) (ariesstorage.Provider, error) {
+		return func(ctx context.Context, keystoreID string) (ariesstorage.Provider, error) {
 			config := &edv.Config{
 				KeystoreService: keystoreSrv,
 				CryptoService:   cryptoSrv,
@@ -78,10 +79,10 @@ func prepareStorageResolver(keystoreSrv keystore.Service, cryptoSrv cryptoapi.Cr
 				CacheProvider:   cacheProvider,
 			}
 
-			return edv.NewStorageProvider(config)
+			return edv.NewStorageProvider(ctx, config)
 		}
 	default:
-		return func(string) (ariesstorage.Provider, error) {
+		return func(context.Context, string) (ariesstorage.Provider, error) {
 			return prepareKMSStorageProvider(storageParams)
 		}
 	}

--- a/cmd/kms-rest/startcmd/start_prepare_secretlock.go
+++ b/cmd/kms-rest/startcmd/start_prepare_secretlock.go
@@ -56,6 +56,9 @@ func preparePrimaryKeyLock(primaryKeyStorage ariesstorage.Provider, keyPath stri
 
 func prepareSecretSplitLock(primaryKeyStorage ariesstorage.Provider, req *http.Request, tlsConfig *tls.Config,
 	cacheProvider ariesstorage.Provider, keyURI, hubAuthURL, hubAuthAPIToken string) (secretlock.Service, error) {
+	_, span := tracer.Start(req.Context(), "prepareSecretSplitLock")
+	defer span.End()
+
 	secret := req.Header.Get(secretHeader)
 	if secret == "" {
 		return nil, errors.New("empty secret share in the header")

--- a/cmd/kms-rest/startcmd/start_test.go
+++ b/cmd/kms-rest/startcmd/start_test.go
@@ -385,6 +385,18 @@ func TestStartCmdWithCacheExpirationParam(t *testing.T) {
 	})
 }
 
+func TestStartCmdWithJaegerURLParam(t *testing.T) {
+	startCmd := GetStartCmd(&mockServer{})
+
+	args := requiredArgs()
+	args = append(args, "--"+jaegerURLFlagName, "http://example.com")
+
+	startCmd.SetArgs(args)
+
+	err := startCmd.Execute()
+	require.NoError(t, err)
+}
+
 func TestStartKMSService(t *testing.T) {
 	const invalidStorageOption = "invalid"
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.5
+	go.opentelemetry.io/otel v0.15.0
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 )
 
 replace github.com/kilic/bls12-381 => github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-metrics-stackdriver v0.2.0/go.mod h1:KLcPyp3dWJAFD+yHisGlJSZktIsTjb50eB72U2YZ9K0=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -825,6 +827,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/otel v0.15.0 h1:CZFy2lPhxd4HlhZnYK8gRyDotksO3Ip9rBweY1vVYJw=
+go.opentelemetry.io/otel v0.15.0/go.mod h1:e4GKElweB8W2gWUqbghw0B8t5MCTccc9212eNHnOHwA=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -935,6 +939,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/auth/zcapld/service_test.go
+++ b/pkg/auth/zcapld/service_test.go
@@ -19,6 +19,7 @@ import (
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/stretchr/testify/require"
 	zcapld2 "github.com/trustbloc/edge-core/pkg/zcapld"
+	"golang.org/x/net/context"
 
 	"github.com/trustbloc/hub-kms/pkg/auth/zcapld"
 )
@@ -44,7 +45,7 @@ func TestService_CreateDIDKey(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		didKey, err := svc.CreateDIDKey()
+		didKey, err := svc.CreateDIDKey(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to create")
 		require.Empty(t, didKey)
@@ -54,7 +55,7 @@ func TestService_CreateDIDKey(t *testing.T) {
 		svc, err := zcapld.New(&mockkms.KeyManager{}, &mockcrypto.Crypto{}, &mockstorage.MockStoreProvider{})
 		require.NoError(t, err)
 
-		didKey, err := svc.CreateDIDKey()
+		didKey, err := svc.CreateDIDKey(context.Background())
 		require.NoError(t, err)
 		require.NotEmpty(t, didKey)
 	})
@@ -96,6 +97,7 @@ func TestService_NewCapability(t *testing.T) {
 		)
 		require.NoError(t, err)
 		result, err := svc.NewCapability(
+			context.Background(),
 			zcapld2.WithInvoker(invoker),
 			zcapld2.WithInvocationTarget(target, "urn:kms:keystore"),
 			zcapld2.WithAllowedActions(allowedAction...),
@@ -113,7 +115,7 @@ func TestService_NewCapability(t *testing.T) {
 			&mockstorage.MockStoreProvider{},
 		)
 		require.NoError(t, err)
-		_, err = svc.NewCapability()
+		_, err = svc.NewCapability(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to create a new signer")
 	})
@@ -125,7 +127,7 @@ func TestService_NewCapability(t *testing.T) {
 			&mockstorage.MockStoreProvider{},
 		)
 		require.NoError(t, err)
-		_, err = svc.NewCapability()
+		_, err = svc.NewCapability(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to create zcap")
 	})
@@ -140,7 +142,7 @@ func TestService_NewCapability(t *testing.T) {
 			}},
 		)
 		require.NoError(t, err)
-		_, err = svc.NewCapability()
+		_, err = svc.NewCapability(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to store zcap")
 	})
@@ -158,7 +160,7 @@ func TestService_Resolve(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		zcap, err := svc.NewCapability()
+		zcap, err := svc.NewCapability(context.Background())
 		require.NotNil(t, zcap)
 		require.NoError(t, err)
 

--- a/pkg/internal/mock/keystore/mock_service.go
+++ b/pkg/internal/mock/keystore/mock_service.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package keystore
 
 import (
+	"context"
+
 	"github.com/google/tink/go/keyset"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
@@ -33,7 +35,7 @@ func NewMockService() *MockService {
 }
 
 // Create creates a new Keystore.
-func (s *MockService) Create(options ...keystore.Option) (*keystore.Keystore, error) {
+func (s *MockService) Create(context.Context, ...keystore.Option) (*keystore.Keystore, error) {
 	if s.CreateErr != nil {
 		return nil, s.CreateErr
 	}
@@ -42,7 +44,7 @@ func (s *MockService) Create(options ...keystore.Option) (*keystore.Keystore, er
 }
 
 // Get retrieves Keystore by ID.
-func (s *MockService) Get(keystoreID string) (*keystore.Keystore, error) {
+func (s *MockService) Get(context.Context, string) (*keystore.Keystore, error) {
 	if s.GetErr != nil {
 		return nil, s.GetErr
 	}
@@ -51,7 +53,7 @@ func (s *MockService) Get(keystoreID string) (*keystore.Keystore, error) {
 }
 
 // Save stores Keystore.
-func (s *MockService) Save(k *keystore.Keystore) error {
+func (s *MockService) Save(context.Context, *keystore.Keystore) error {
 	if s.SaveErr != nil {
 		return s.SaveErr
 	}
@@ -60,7 +62,7 @@ func (s *MockService) Save(k *keystore.Keystore) error {
 }
 
 // GetKeyHandle retrieves key handle by keyID.
-func (s *MockService) GetKeyHandle(keyID string) (interface{}, error) {
+func (s *MockService) GetKeyHandle(context.Context, string) (interface{}, error) {
 	if s.GetKeyHandleErr != nil {
 		return nil, s.GetKeyHandleErr
 	}

--- a/pkg/internal/mock/kms/mock_service.go
+++ b/pkg/internal/mock/kms/mock_service.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package kms
 
 import (
+	"context"
+
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -46,7 +48,7 @@ func NewMockService() *MockService {
 }
 
 // CreateKey creates a new key.
-func (s *MockService) CreateKey(keystoreID string, kt kms.KeyType) (string, error) {
+func (s *MockService) CreateKey(context.Context, string, kms.KeyType) (string, error) {
 	if s.CreateKeyErr != nil {
 		return "", s.CreateKeyErr
 	}
@@ -55,7 +57,7 @@ func (s *MockService) CreateKey(keystoreID string, kt kms.KeyType) (string, erro
 }
 
 // ExportKey exports a public key.
-func (s *MockService) ExportKey(keystoreID, keyID string) ([]byte, error) {
+func (s *MockService) ExportKey(context.Context, string, string) ([]byte, error) {
 	if s.ExportKeyErr != nil {
 		return nil, s.ExportKeyErr
 	}
@@ -64,7 +66,7 @@ func (s *MockService) ExportKey(keystoreID, keyID string) ([]byte, error) {
 }
 
 // Sign signs a message.
-func (s *MockService) Sign(keystoreID, keyID string, msg []byte) ([]byte, error) {
+func (s *MockService) Sign(context.Context, string, string, []byte) ([]byte, error) {
 	if s.SignErr != nil {
 		return nil, s.SignErr
 	}
@@ -73,7 +75,7 @@ func (s *MockService) Sign(keystoreID, keyID string, msg []byte) ([]byte, error)
 }
 
 // Verify verifies a signature for the given message.
-func (s *MockService) Verify(keystoreID, keyID string, sig, msg []byte) error {
+func (s *MockService) Verify(context.Context, string, string, []byte, []byte) error {
 	if s.VerifyErr != nil {
 		return s.VerifyErr
 	}
@@ -82,7 +84,7 @@ func (s *MockService) Verify(keystoreID, keyID string, sig, msg []byte) error {
 }
 
 // Encrypt encrypts a message with aad.
-func (s *MockService) Encrypt(keystoreID, keyID string, msg, aad []byte) ([]byte, []byte, error) {
+func (s *MockService) Encrypt(context.Context, string, string, []byte, []byte) ([]byte, []byte, error) {
 	if s.EncryptErr != nil {
 		return nil, nil, s.EncryptErr
 	}
@@ -91,7 +93,7 @@ func (s *MockService) Encrypt(keystoreID, keyID string, msg, aad []byte) ([]byte
 }
 
 // Decrypt decrypts a cipher with aad and given nonce.
-func (s *MockService) Decrypt(keystoreID, keyID string, cipher, aad, nonce []byte) ([]byte, error) {
+func (s *MockService) Decrypt(context.Context, string, string, []byte, []byte, []byte) ([]byte, error) {
 	if s.DecryptErr != nil {
 		return nil, s.DecryptErr
 	}
@@ -100,7 +102,7 @@ func (s *MockService) Decrypt(keystoreID, keyID string, cipher, aad, nonce []byt
 }
 
 // ComputeMAC computes message authentication code (MAC) for data.
-func (s *MockService) ComputeMAC(keystoreID, keyID string, data []byte) ([]byte, error) {
+func (s *MockService) ComputeMAC(context.Context, string, string, []byte) ([]byte, error) {
 	if s.ComputeMACErr != nil {
 		return nil, s.ComputeMACErr
 	}
@@ -109,7 +111,7 @@ func (s *MockService) ComputeMAC(keystoreID, keyID string, data []byte) ([]byte,
 }
 
 // VerifyMAC determines if mac is a correct authentication code (MAC) for data.
-func (s *MockService) VerifyMAC(keystoreID, keyID string, mac, data []byte) error {
+func (s *MockService) VerifyMAC(context.Context, string, string, []byte, []byte) error {
 	if s.VerifyMACErr != nil {
 		return s.VerifyMACErr
 	}
@@ -118,8 +120,8 @@ func (s *MockService) VerifyMAC(keystoreID, keyID string, mac, data []byte) erro
 }
 
 // WrapKey wraps cek for the recipient with public key 'recipientPubKey'.
-func (s *MockService) WrapKey(keystoreID, keyID string, cek, apu, apv []byte,
-	recipientPubKey *crypto.PublicKey) (*crypto.RecipientWrappedKey, error) {
+func (s *MockService) WrapKey(context.Context, string, string, []byte, []byte, []byte,
+	*crypto.PublicKey) (*crypto.RecipientWrappedKey, error) {
 	if s.WrapKeyErr != nil {
 		return nil, s.WrapKeyErr
 	}
@@ -128,8 +130,8 @@ func (s *MockService) WrapKey(keystoreID, keyID string, cek, apu, apv []byte,
 }
 
 // UnwrapKey unwraps a key in recipientWK.
-func (s *MockService) UnwrapKey(keystoreID, keyID string, recipientWK *crypto.RecipientWrappedKey,
-	senderPubKey *crypto.PublicKey) ([]byte, error) {
+func (s *MockService) UnwrapKey(context.Context, string, string, *crypto.RecipientWrappedKey,
+	*crypto.PublicKey) ([]byte, error) {
 	if s.UnwrapKeyErr != nil {
 		return nil, s.UnwrapKeyErr
 	}
@@ -138,7 +140,7 @@ func (s *MockService) UnwrapKey(keystoreID, keyID string, recipientWK *crypto.Re
 }
 
 // Easy seals a message with a provided nonce.
-func (s *MockService) Easy(keystoreID, keyID string, payload, nonce, theirPub []byte) ([]byte, error) {
+func (s *MockService) Easy(context.Context, string, string, []byte, []byte, []byte) ([]byte, error) {
 	if s.EasyErr != nil {
 		return nil, s.EasyErr
 	}
@@ -147,7 +149,7 @@ func (s *MockService) Easy(keystoreID, keyID string, payload, nonce, theirPub []
 }
 
 // EasyOpen unseals a message sealed with Easy, where the nonce is provided.
-func (s *MockService) EasyOpen(keystoreID string, cipherText, nonce, theirPub, myPub []byte) ([]byte, error) {
+func (s *MockService) EasyOpen(context.Context, string, []byte, []byte, []byte, []byte) ([]byte, error) {
 	if s.EasyOpenErr != nil {
 		return nil, s.EasyOpenErr
 	}
@@ -156,7 +158,7 @@ func (s *MockService) EasyOpen(keystoreID string, cipherText, nonce, theirPub, m
 }
 
 // SealOpen decrypts a payload encrypted with Seal.
-func (s *MockService) SealOpen(keystoreID string, cipher, myPub []byte) ([]byte, error) {
+func (s *MockService) SealOpen(context.Context, string, []byte, []byte) ([]byte, error) {
 	if s.SealOpenErr != nil {
 		return nil, s.SealOpenErr
 	}

--- a/pkg/keystore/service_test.go
+++ b/pkg/keystore/service_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package keystore_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -78,7 +79,7 @@ func TestCreate(t *testing.T) {
 			keystore.WithCreatedAt(&createdAt),
 		}
 
-		keystoreID, err := srv.Create(opts...)
+		keystoreID, err := srv.Create(context.Background(), opts...)
 
 		require.NotEmpty(t, keystoreID)
 		require.NoError(t, err)
@@ -92,7 +93,9 @@ func TestCreate(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		keystoreID, err := srv.Create(keystore.WithID(testKeystoreID), keystore.WithDelegateKeyType(testKeyType))
+		keystoreID, err := srv.Create(context.Background(),
+			keystore.WithID(testKeystoreID),
+			keystore.WithDelegateKeyType(testKeyType))
 
 		require.Empty(t, keystoreID)
 		require.Error(t, err)
@@ -106,7 +109,9 @@ func TestCreate(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		keystoreID, err := srv.Create(keystore.WithID(testKeystoreID), keystore.WithRecipientKeyType(testKeyType))
+		keystoreID, err := srv.Create(context.Background(),
+			keystore.WithID(testKeystoreID),
+			keystore.WithRecipientKeyType(testKeyType))
 
 		require.Empty(t, keystoreID)
 		require.Error(t, err)
@@ -120,7 +125,9 @@ func TestCreate(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		keystoreID, err := srv.Create(keystore.WithID(testKeystoreID), keystore.WithMACKeyType(testKeyType))
+		keystoreID, err := srv.Create(context.Background(),
+			keystore.WithID(testKeystoreID),
+			keystore.WithMACKeyType(testKeyType))
 
 		require.Empty(t, keystoreID)
 		require.Error(t, err)
@@ -134,7 +141,7 @@ func TestCreate(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		keystoreID, err := srv.Create(keystore.WithID(testKeystoreID))
+		keystoreID, err := srv.Create(context.Background(), keystore.WithID(testKeystoreID))
 		require.Empty(t, keystoreID)
 		require.Error(t, err)
 	})
@@ -149,7 +156,7 @@ func TestGet(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		k, err := srv.Get(testKeystoreID)
+		k, err := srv.Get(context.Background(), testKeystoreID)
 
 		require.NotNil(t, k)
 		require.NoError(t, err)
@@ -163,7 +170,7 @@ func TestGet(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		k, err := srv.Get(testKeystoreID)
+		k, err := srv.Get(context.Background(), testKeystoreID)
 
 		require.Nil(t, k)
 		require.Error(t, err)
@@ -177,7 +184,7 @@ func TestSave(t *testing.T) {
 		require.NoError(t, err)
 
 		k := testKeystore()
-		err = srv.Save(&k)
+		err = srv.Save(context.Background(), &k)
 		require.NoError(t, err)
 	})
 
@@ -190,7 +197,7 @@ func TestSave(t *testing.T) {
 		require.NoError(t, err)
 
 		k := testKeystore()
-		err = srv.Save(&k)
+		err = srv.Save(context.Background(), &k)
 		require.Error(t, err)
 	})
 }
@@ -207,7 +214,7 @@ func TestGetKeyHandle(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		kh, err := srv.GetKeyHandle(testKeyID)
+		kh, err := srv.GetKeyHandle(context.Background(), testKeyID)
 		require.NotNil(t, kh)
 		require.NoError(t, err)
 	})
@@ -220,7 +227,7 @@ func TestGetKeyHandle(t *testing.T) {
 		require.NotNil(t, srv)
 		require.NoError(t, err)
 
-		kh, err := srv.GetKeyHandle(testKeyID)
+		kh, err := srv.GetKeyHandle(context.Background(), testKeyID)
 		require.Nil(t, kh)
 		require.Error(t, err)
 	})

--- a/pkg/kms/service.go
+++ b/pkg/kms/service.go
@@ -7,33 +7,39 @@ SPDX-License-Identifier: Apache-2.0
 package kms
 
 import (
+	"context"
+	"time"
+
 	"github.com/google/tink/go/keyset"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/keyio"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/trustbloc/hub-kms/pkg/keystore"
 )
 
 // Service provides kms/crypto functionality.
 type Service interface {
-	CreateKey(keystoreID string, kt kms.KeyType) (string, error)
-	ExportKey(keystoreID, keyID string) ([]byte, error)
-	Sign(keystoreID, keyID string, msg []byte) ([]byte, error)
-	Verify(keystoreID, keyID string, sig, msg []byte) error
-	Encrypt(keystoreID, keyID string, msg, aad []byte) ([]byte, []byte, error)
-	Decrypt(keystoreID, keyID string, cipher, aad, nonce []byte) ([]byte, error)
-	ComputeMAC(keystoreID, keyID string, data []byte) ([]byte, error)
-	VerifyMAC(keystoreID, keyID string, mac, data []byte) error
-	WrapKey(keystoreID, keyID string, cek, apu, apv []byte,
+	CreateKey(ctx context.Context, keystoreID string, kt kms.KeyType) (string, error)
+	ExportKey(ctx context.Context, keystoreID, keyID string) ([]byte, error)
+	Sign(ctx context.Context, keystoreID, keyID string, msg []byte) ([]byte, error)
+	Verify(ctx context.Context, keystoreID, keyID string, sig, msg []byte) error
+	Encrypt(ctx context.Context, keystoreID, keyID string, msg, aad []byte) ([]byte, []byte, error)
+	Decrypt(ctx context.Context, keystoreID, keyID string, cipher, aad, nonce []byte) ([]byte, error)
+	ComputeMAC(ctx context.Context, keystoreID, keyID string, data []byte) ([]byte, error)
+	VerifyMAC(ctx context.Context, keystoreID, keyID string, mac, data []byte) error
+	WrapKey(ctx context.Context, keystoreID, keyID string, cek, apu, apv []byte,
 		recipientPubKey *crypto.PublicKey) (*crypto.RecipientWrappedKey, error)
-	UnwrapKey(keystoreID, keyID string, recipientWK *crypto.RecipientWrappedKey,
+	UnwrapKey(ctx context.Context, keystoreID, keyID string, recipientWK *crypto.RecipientWrappedKey,
 		senderPubKey *crypto.PublicKey) ([]byte, error)
 
 	// CryptoBox operations.
-	Easy(keystoreID, keyID string, payload, nonce, theirPub []byte) ([]byte, error)
-	EasyOpen(keystoreID string, cipherText, nonce, theirPub, myPub []byte) ([]byte, error)
-	SealOpen(keystoreID string, cipher, myPub []byte) ([]byte, error)
+	Easy(ctx context.Context, keystoreID, keyID string, payload, nonce, theirPub []byte) ([]byte, error)
+	EasyOpen(ctx context.Context, keystoreID string, cipherText, nonce, theirPub, myPub []byte) ([]byte, error)
+	SealOpen(ctx context.Context, keystoreID string, cipher, myPub []byte) ([]byte, error)
 }
 
 // CryptoBox provides an elliptic-curve-based authenticated encryption scheme (used in legacy packer).
@@ -58,6 +64,8 @@ type service struct {
 	cryptoBox  CryptoBox
 }
 
+var tracer = otel.Tracer("hub-kms/kms") //nolint:gochecknoglobals // ignore
+
 // NewService returns a new Service instance.
 func NewService(provider Provider) Service {
 	return &service{
@@ -69,59 +77,111 @@ func NewService(provider Provider) Service {
 }
 
 // CreateKey creates a new key and associates it with Keystore.
-func (s *service) CreateKey(keystoreID string, kt kms.KeyType) (string, error) {
+func (s *service) CreateKey(ctx context.Context, keystoreID string,
+	kt kms.KeyType) (string, error) { //nolint:funlen // TODO refactor
+	trCtx, span := tracer.Start(ctx, "kms:CreateKey")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+
+	start := time.Now()
+
 	keyID, _, err := s.keyManager.Create(kt)
 	if err != nil {
 		return "", NewServiceError(createKeyFailed, err)
 	}
 
-	k, err := s.keystore.Get(keystoreID)
+	span.AddEvent("Create completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
+	span.SetAttributes(label.String("keyID", keyID))
+
+	startGet := time.Now()
+
+	k, err := s.keystore.Get(trCtx, keystoreID)
 	if err != nil {
 		return "", NewServiceError(getKeystoreFailed, err)
 	}
 
+	span.AddEvent("keystore.Get completed",
+		trace.WithAttributes(label.String("duration", time.Since(startGet).String())))
+
 	k.KeyIDs = append(k.KeyIDs, keyID)
 
-	err = s.keystore.Save(k)
+	startPut := time.Now()
+
+	err = s.keystore.Save(trCtx, k)
 	if err != nil {
 		return "", NewServiceError(saveKeystoreFailed, err)
 	}
+
+	span.AddEvent("keystore.Save completed",
+		trace.WithAttributes(label.String("duration", time.Since(startPut).String())))
 
 	return keyID, nil
 }
 
 // ExportKey exports a public key.
-func (s *service) ExportKey(keystoreID, keyID string) ([]byte, error) {
-	if err := s.checkKey(keystoreID, keyID); err != nil {
+func (s *service) ExportKey(ctx context.Context, keystoreID, keyID string) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:ExportKey")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	if err := s.checkKey(trCtx, span, keystoreID, keyID); err != nil {
 		return nil, err
 	}
+
+	start := time.Now()
 
 	b, err := s.keyManager.ExportPubKeyBytes(keyID)
 	if err != nil {
 		return nil, NewServiceError(exportKeyFailed, err)
 	}
 
+	span.AddEvent("ExportPubKeyBytes completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return b, nil
 }
 
 // Sign signs a message.
-func (s *service) Sign(keystoreID, keyID string, msg []byte) ([]byte, error) {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+//nolint:dupl // TODO refactor
+func (s *service) Sign(ctx context.Context, keystoreID, keyID string, msg []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:Sign")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return nil, err
 	}
+
+	start := time.Now()
 
 	sig, err := s.crypto.Sign(msg, kh)
 	if err != nil {
 		return nil, NewServiceError(signMessageFailed, err)
 	}
 
+	span.AddEvent("Sign completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return sig, nil
 }
 
 // Verify verifies a signature for the message.
-func (s *service) Verify(keystoreID, keyID string, sig, msg []byte) error {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+func (s *service) Verify(ctx context.Context, keystoreID, keyID string, sig, msg []byte) error {
+	trCtx, span := tracer.Start(ctx, "kms:Verify")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return err
 	}
@@ -131,104 +191,176 @@ func (s *service) Verify(keystoreID, keyID string, sig, msg []byte) error {
 		return NewServiceError(noPublicKeyFailure, err)
 	}
 
+	start := time.Now()
+
 	err = s.crypto.Verify(sig, msg, pub)
 	if err != nil {
 		return NewServiceError(verifySignatureFailed, err)
 	}
 
+	span.AddEvent("Verify completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return nil
 }
 
 // Encrypt encrypts a message with additional authenticated data (AAD).
-func (s *service) Encrypt(keystoreID, keyID string, msg, aad []byte) ([]byte, []byte, error) {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+func (s *service) Encrypt(ctx context.Context, keystoreID, keyID string, msg, aad []byte) ([]byte, []byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:Encrypt")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	start := time.Now()
 
 	cipher, nonce, err := s.crypto.Encrypt(msg, aad, kh)
 	if err != nil {
 		return nil, nil, NewServiceError(encryptMessageFailed, err)
 	}
 
+	span.AddEvent("Encrypt completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return cipher, nonce, nil
 }
 
 // Decrypt decrypts a cipher with AAD and a nonce.
-func (s *service) Decrypt(keystoreID, keyID string, cipher, aad, nonce []byte) ([]byte, error) {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+func (s *service) Decrypt(ctx context.Context, keystoreID, keyID string, cipher, aad, nonce []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:Decrypt")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return nil, err
 	}
+
+	start := time.Now()
 
 	plain, err := s.crypto.Decrypt(cipher, aad, nonce, kh)
 	if err != nil {
 		return nil, NewServiceError(decryptCipherFailed, err)
 	}
 
+	span.AddEvent("Decrypt completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return plain, nil
 }
 
 // ComputeMAC computes message authentication code (MAC) for data.
-func (s *service) ComputeMAC(keystoreID, keyID string, data []byte) ([]byte, error) {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+//nolint:dupl // TODO refactor
+func (s *service) ComputeMAC(ctx context.Context, keystoreID, keyID string, data []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:ComputeMAC")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return nil, err
 	}
+
+	start := time.Now()
 
 	mac, err := s.crypto.ComputeMAC(data, kh)
 	if err != nil {
 		return nil, NewServiceError(computeMACFailed, err)
 	}
 
+	span.AddEvent("ComputeMAC completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return mac, nil
 }
 
 // VerifyMAC determines if the given mac is a correct message authentication code (MAC) for data.
-func (s *service) VerifyMAC(keystoreID, keyID string, mac, data []byte) error {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+func (s *service) VerifyMAC(ctx context.Context, keystoreID, keyID string, mac, data []byte) error {
+	trCtx, span := tracer.Start(ctx, "kms:VerifyMAC")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return err
 	}
+
+	start := time.Now()
 
 	err = s.crypto.VerifyMAC(mac, data, kh)
 	if err != nil {
 		return NewServiceError(verifyMACFailed, err)
 	}
 
+	span.AddEvent("VerifyMAC completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return nil
 }
 
 // WrapKey wraps cek for the recipient with public key 'recipientPubKey'.
-func (s *service) WrapKey(keystoreID, keyID string, cek, apu, apv []byte,
+func (s *service) WrapKey(ctx context.Context, keystoreID, keyID string, cek, apu, apv []byte,
 	recipientPubKey *crypto.PublicKey) (*crypto.RecipientWrappedKey, error) {
+	trCtx, span := tracer.Start(ctx, "kms:WrapKey")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
 	if keyID != "" {
-		kh, err := s.getKeyHandle(keystoreID, keyID)
+		kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 		if err != nil {
 			return nil, err
 		}
 
 		// ECDH-1PU key wrapping (Authcrypt)
+		start := time.Now()
+
 		recipientWrappedKey, err := s.crypto.WrapKey(cek, apu, apv, recipientPubKey, crypto.WithSender(kh))
 		if err != nil {
 			return nil, NewServiceError(wrapKeyFailed, err)
 		}
 
+		span.AddEvent("WrapKey (Authcrypt) completed",
+			trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 		return recipientWrappedKey, nil
 	}
+
+	start := time.Now()
 
 	recipientWrappedKey, err := s.crypto.WrapKey(cek, apu, apv, recipientPubKey)
 	if err != nil {
 		return nil, NewServiceError(wrapKeyFailed, err)
 	}
 
+	span.AddEvent("WrapKey (Anoncrypt) completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return recipientWrappedKey, nil
 }
 
 // UnwrapKey unwraps a key in recipientWK.
-func (s *service) UnwrapKey(keystoreID, keyID string, recipientWK *crypto.RecipientWrappedKey,
+func (s *service) UnwrapKey(ctx context.Context, keystoreID, keyID string, recipientWK *crypto.RecipientWrappedKey,
 	senderPubKey *crypto.PublicKey) ([]byte, error) {
-	kh, err := s.getKeyHandle(keystoreID, keyID)
+	trCtx, span := tracer.Start(ctx, "kms:UnwrapKey")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	kh, err := s.getKeyHandle(trCtx, span, keystoreID, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -240,24 +372,34 @@ func (s *service) UnwrapKey(keystoreID, keyID string, recipientWK *crypto.Recipi
 		}
 
 		// ECDH-1PU key unwrapping (Authcrypt)
+		start := time.Now()
+
 		cek, e := s.crypto.UnwrapKey(recipientWK, kh, crypto.WithSender(senderKH))
 		if e != nil {
 			return nil, NewServiceError(unwrapKeyFailed, e)
 		}
 
+		span.AddEvent("UnwrapKey (Authcrypt) completed",
+			trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 		return cek, nil
 	}
+
+	start := time.Now()
 
 	cek, err := s.crypto.UnwrapKey(recipientWK, kh)
 	if err != nil {
 		return nil, NewServiceError(unwrapKeyFailed, err)
 	}
 
+	span.AddEvent("UnwrapKey (Anoncrypt) completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return cek, nil
 }
 
-func (s *service) getKeyHandle(keystoreID, keyID string) (interface{}, error) {
-	if err := s.checkKey(keystoreID, keyID); err != nil {
+func (s *service) getKeyHandle(ctx context.Context, span trace.Span, keystoreID, keyID string) (interface{}, error) {
+	if err := s.checkKey(ctx, span, keystoreID, keyID); err != nil {
 		return nil, err
 	}
 
@@ -269,11 +411,16 @@ func (s *service) getKeyHandle(keystoreID, keyID string) (interface{}, error) {
 	return kh, nil
 }
 
-func (s *service) checkKey(keystoreID, keyID string) error {
-	k, err := s.keystore.Get(keystoreID)
+func (s *service) checkKey(ctx context.Context, span trace.Span, keystoreID, keyID string) error {
+	start := time.Now()
+
+	k, err := s.keystore.Get(ctx, keystoreID)
 	if err != nil {
 		return NewServiceError(getKeystoreFailed, err)
 	}
+
+	span.AddEvent("keystore.Get completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
 
 	if len(k.KeyIDs) == 0 {
 		return NewServiceError(noKeysFailure, nil)

--- a/pkg/kms/service_cryptobox.go
+++ b/pkg/kms/service_cryptobox.go
@@ -6,44 +6,94 @@ SPDX-License-Identifier: Apache-2.0
 
 package kms
 
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/trace"
+)
+
 // Easy seals a message with a provided nonce.
-func (s *service) Easy(keystoreID, keyID string, payload, nonce, theirPub []byte) ([]byte, error) {
-	if err := s.checkKey(keystoreID, keyID); err != nil {
+func (s *service) Easy(ctx context.Context, keystoreID, keyID string, payload, nonce, theirPub []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:Easy")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+	span.SetAttributes(label.String("keyID", keyID))
+
+	if err := s.checkKey(trCtx, span, keystoreID, keyID); err != nil {
 		return nil, err
 	}
+
+	start := time.Now()
 
 	cipher, err := s.cryptoBox.Easy(payload, nonce, theirPub, keyID)
 	if err != nil {
 		return nil, NewServiceError(easyMessageFailed, err)
 	}
 
+	span.AddEvent("Easy completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return cipher, nil
 }
 
 // EasyOpen unseals a message sealed with Easy, where the nonce is provided.
-func (s *service) EasyOpen(keystoreID string, cipherText, nonce, theirPub, myPub []byte) ([]byte, error) {
-	if _, err := s.keystore.Get(keystoreID); err != nil {
+func (s *service) EasyOpen(ctx context.Context, keystoreID string,
+	cipherText, nonce, theirPub, myPub []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:EasyOpen")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+
+	startGet := time.Now()
+
+	if _, err := s.keystore.Get(trCtx, keystoreID); err != nil {
 		return nil, NewServiceError(getKeystoreFailed, err)
 	}
+
+	span.AddEvent("keystore.Get completed",
+		trace.WithAttributes(label.String("duration", time.Since(startGet).String())))
+
+	start := time.Now()
 
 	plain, err := s.cryptoBox.EasyOpen(cipherText, nonce, theirPub, myPub)
 	if err != nil {
 		return nil, NewServiceError(easyOpenMessageFailed, err)
 	}
 
+	span.AddEvent("EasyOpen completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
+
 	return plain, nil
 }
 
 // SealOpen decrypts a payload encrypted with Seal.
-func (s *service) SealOpen(keystoreID string, cipher, myPub []byte) ([]byte, error) {
-	if _, err := s.keystore.Get(keystoreID); err != nil {
+func (s *service) SealOpen(ctx context.Context, keystoreID string, cipher, myPub []byte) ([]byte, error) {
+	trCtx, span := tracer.Start(ctx, "kms:SealOpen")
+	defer span.End()
+
+	span.SetAttributes(label.String("keystoreID", keystoreID))
+
+	startGet := time.Now()
+
+	if _, err := s.keystore.Get(trCtx, keystoreID); err != nil {
 		return nil, NewServiceError(getKeystoreFailed, err)
 	}
+
+	span.AddEvent("keystore.Get completed",
+		trace.WithAttributes(label.String("duration", time.Since(startGet).String())))
+
+	start := time.Now()
 
 	plain, err := s.cryptoBox.SealOpen(cipher, myPub)
 	if err != nil {
 		return nil, NewServiceError(sealOpenPayloadFailed, err)
 	}
+
+	span.AddEvent("SealOpen completed",
+		trace.WithAttributes(label.String("duration", time.Since(start).String())))
 
 	return plain, nil
 }

--- a/pkg/kms/service_cryptobox_test.go
+++ b/pkg/kms/service_cryptobox_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package kms_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestEasy(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, err := srv.Easy(testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
+		cipher, err := srv.Easy(context.Background(), testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
 			[]byte(testTheirPub))
 
 		require.NotEmpty(t, cipher)
@@ -51,7 +52,7 @@ func TestEasy(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, err := srv.Easy(testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
+		cipher, err := srv.Easy(context.Background(), testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
 			[]byte(testTheirPub))
 
 		require.Empty(t, cipher)
@@ -71,7 +72,7 @@ func TestEasy(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, err := srv.Easy(testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
+		cipher, err := srv.Easy(context.Background(), testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
 			[]byte(testTheirPub))
 
 		require.Empty(t, cipher)
@@ -92,8 +93,8 @@ func TestEasy(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, err := srv.Easy(testKeystoreID, "invalidKeyID", []byte(testMessage), []byte(testNonce),
-			[]byte(testTheirPub))
+		cipher, err := srv.Easy(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMessage),
+			[]byte(testNonce), []byte(testTheirPub))
 
 		require.Empty(t, cipher)
 		require.Error(t, err)
@@ -113,7 +114,7 @@ func TestEasy(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, err := srv.Easy(testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
+		cipher, err := srv.Easy(context.Background(), testKeystoreID, testKeyID, []byte(testMessage), []byte(testNonce),
 			[]byte(testTheirPub))
 
 		require.Empty(t, cipher)
@@ -135,8 +136,8 @@ func TestEasyOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.EasyOpen(testKeystoreID, []byte(testCipherText), []byte(testNonce), []byte(testTheirPub),
-			[]byte(testMyPub))
+		plain, err := srv.EasyOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testNonce),
+			[]byte(testTheirPub), []byte(testMyPub))
 
 		require.NotEmpty(t, plain)
 		require.NoError(t, err)
@@ -150,8 +151,8 @@ func TestEasyOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.EasyOpen(testKeystoreID, []byte(testCipherText), []byte(testNonce), []byte(testTheirPub),
-			[]byte(testMyPub))
+		plain, err := srv.EasyOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testNonce),
+			[]byte(testTheirPub), []byte(testMyPub))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -170,8 +171,8 @@ func TestEasyOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.EasyOpen(testKeystoreID, []byte(testCipherText), []byte(testNonce), []byte(testTheirPub),
-			[]byte(testMyPub))
+		plain, err := srv.EasyOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testNonce),
+			[]byte(testTheirPub), []byte(testMyPub))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -192,7 +193,7 @@ func TestSealOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.SealOpen(testKeystoreID, []byte(testCipherText), []byte(testMyPub))
+		plain, err := srv.SealOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testMyPub))
 
 		require.NotEmpty(t, plain)
 		require.NoError(t, err)
@@ -206,7 +207,7 @@ func TestSealOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.SealOpen(testKeystoreID, []byte(testCipherText), []byte(testMyPub))
+		plain, err := srv.SealOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testMyPub))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -225,7 +226,7 @@ func TestSealOpen(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.SealOpen(testKeystoreID, []byte(testCipherText), []byte(testMyPub))
+		plain, err := srv.SealOpen(context.Background(), testKeystoreID, []byte(testCipherText), []byte(testMyPub))
 
 		require.Empty(t, plain)
 		require.Error(t, err)

--- a/pkg/kms/service_test.go
+++ b/pkg/kms/service_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package kms_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -56,7 +57,7 @@ func TestCreateKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		keyID, err := srv.CreateKey(testKeystoreID, testKeyType)
+		keyID, err := srv.CreateKey(context.Background(), testKeystoreID, testKeyType)
 		require.Equal(t, testKeyID, keyID)
 		require.NoError(t, err)
 
@@ -70,7 +71,7 @@ func TestCreateKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		keyID, err := srv.CreateKey(testKeystoreID, testKeyType)
+		keyID, err := srv.CreateKey(context.Background(), testKeystoreID, testKeyType)
 
 		require.Empty(t, keyID)
 		require.Error(t, err)
@@ -84,7 +85,7 @@ func TestCreateKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		keyID, err := srv.CreateKey(testKeystoreID, testKeyType)
+		keyID, err := srv.CreateKey(context.Background(), testKeystoreID, testKeyType)
 
 		require.Empty(t, keyID)
 		require.Error(t, err)
@@ -104,7 +105,7 @@ func TestCreateKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		keyID, err := srv.CreateKey(testKeystoreID, testKeyType)
+		keyID, err := srv.CreateKey(context.Background(), testKeystoreID, testKeyType)
 
 		require.Empty(t, keyID)
 		require.Error(t, err)
@@ -126,7 +127,7 @@ func TestExportKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		pub, err := srv.ExportKey(testKeystoreID, testKeyID)
+		pub, err := srv.ExportKey(context.Background(), testKeystoreID, testKeyID)
 
 		require.NotEmpty(t, pub)
 		require.NoError(t, err)
@@ -139,7 +140,7 @@ func TestExportKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		pub, err := srv.ExportKey(testKeystoreID, testKeyID)
+		pub, err := srv.ExportKey(context.Background(), testKeystoreID, testKeyID)
 
 		require.Empty(t, pub)
 		require.Error(t, err)
@@ -157,7 +158,7 @@ func TestExportKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		pub, err := srv.ExportKey(testKeystoreID, testKeyID)
+		pub, err := srv.ExportKey(context.Background(), testKeystoreID, testKeyID)
 
 		require.Empty(t, pub)
 		require.Error(t, err)
@@ -176,7 +177,7 @@ func TestExportKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		pub, err := srv.ExportKey(testKeystoreID, "invalidKeyID")
+		pub, err := srv.ExportKey(context.Background(), testKeystoreID, "invalidKeyID")
 
 		require.Empty(t, pub)
 		require.Error(t, err)
@@ -196,7 +197,7 @@ func TestExportKey(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		pub, err := srv.ExportKey(testKeystoreID, testKeyID)
+		pub, err := srv.ExportKey(context.Background(), testKeystoreID, testKeyID)
 
 		require.Empty(t, pub)
 		require.Error(t, err)
@@ -218,7 +219,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.NotEmpty(t, sig)
 		require.NoError(t, err)
@@ -231,7 +232,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -249,7 +250,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -268,7 +269,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, "invalidKeyID", []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -288,7 +289,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -308,7 +309,7 @@ func TestSign(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.Sign(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.Sign(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -333,7 +334,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err = srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.NoError(t, err)
 	})
 
@@ -344,7 +345,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err := srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "get keystore failed: get keystore error", err.Error())
 	})
@@ -360,7 +361,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err := srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "no keys defined", err.Error())
 	})
@@ -377,7 +378,9 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.Verify(testKeystoreID, "invalidKeyID", []byte(testSignature), []byte(testMessage))
+		err := srv.Verify(context.Background(), testKeystoreID, "invalidKeyID", []byte(testSignature),
+			[]byte(testMessage))
+
 		require.Error(t, err)
 		require.Equal(t, "invalid key", err.Error())
 	})
@@ -395,7 +398,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err := srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "get key failed: get key error", err.Error())
 	})
@@ -416,7 +419,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err = srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 	})
 
@@ -437,7 +440,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err = srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "verify signature failed: verify msg: invalid signature", err.Error())
 	})
@@ -459,7 +462,7 @@ func TestVerify(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.Verify(testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
+		err = srv.Verify(context.Background(), testKeystoreID, testKeyID, []byte(testSignature), []byte(testMessage))
 		require.Error(t, err)
 	})
 }
@@ -479,7 +482,9 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD))
+
 		require.NoError(t, err)
 		require.NotEmpty(t, cipher)
 		require.NotEmpty(t, nonce)
@@ -492,7 +497,8 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD))
 
 		require.Empty(t, cipher)
 		require.Empty(t, nonce)
@@ -511,7 +517,8 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD))
 
 		require.Empty(t, cipher)
 		require.Empty(t, nonce)
@@ -531,7 +538,8 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, "invalidKeyID", []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMessage),
+			[]byte(testAAD))
 
 		require.Empty(t, cipher)
 		require.Empty(t, nonce)
@@ -552,7 +560,8 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD))
 
 		require.Empty(t, cipher)
 		require.Empty(t, nonce)
@@ -573,7 +582,8 @@ func TestEncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		cipher, nonce, err := srv.Encrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD))
+		cipher, nonce, err := srv.Encrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD))
 
 		require.Empty(t, cipher)
 		require.Empty(t, nonce)
@@ -596,7 +606,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.NotEmpty(t, plain)
 		require.NoError(t, err)
@@ -609,7 +620,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -627,7 +639,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -646,7 +659,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, "invalidKeyID", []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -666,7 +680,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -686,7 +701,8 @@ func TestDecrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		plain, err := srv.Decrypt(testKeystoreID, testKeyID, []byte(testMessage), []byte(testAAD), []byte(testNonce))
+		plain, err := srv.Decrypt(context.Background(), testKeystoreID, testKeyID, []byte(testMessage),
+			[]byte(testAAD), []byte(testNonce))
 
 		require.Empty(t, plain)
 		require.Error(t, err)
@@ -708,7 +724,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.NotEmpty(t, sig)
 		require.NoError(t, err)
@@ -721,7 +737,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -739,7 +755,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -758,7 +774,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, "invalidKeyID", []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -778,7 +794,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -798,7 +814,7 @@ func TestComputeMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		sig, err := srv.ComputeMAC(testKeystoreID, testKeyID, []byte(testMessage))
+		sig, err := srv.ComputeMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMessage))
 
 		require.Empty(t, sig)
 		require.Error(t, err)
@@ -823,7 +839,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.VerifyMAC(testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
+		err = srv.VerifyMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
 		require.NoError(t, err)
 	})
 
@@ -834,7 +850,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.VerifyMAC(testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
+		err := srv.VerifyMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "get keystore failed: get keystore error", err.Error())
 	})
@@ -850,7 +866,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.VerifyMAC(testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
+		err := srv.VerifyMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "no keys defined", err.Error())
 	})
@@ -867,7 +883,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.VerifyMAC(testKeystoreID, "invalidKeyID", []byte(testMAC), []byte(testMessage))
+		err := srv.VerifyMAC(context.Background(), testKeystoreID, "invalidKeyID", []byte(testMAC), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "invalid key", err.Error())
 	})
@@ -885,7 +901,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err := srv.VerifyMAC(testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
+		err := srv.VerifyMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "get key failed: get key error", err.Error())
 	})
@@ -909,7 +925,7 @@ func TestVerifyMAC(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		err = srv.VerifyMAC(testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
+		err = srv.VerifyMAC(context.Background(), testKeystoreID, testKeyID, []byte(testMAC), []byte(testMessage))
 		require.Error(t, err)
 		require.Equal(t, "verify MAC failed: verify MAC error", err.Error())
 	})
@@ -923,7 +939,7 @@ func TestWrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, "", []byte("cek"), []byte("apu"), []byte("apv"),
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, "", []byte("cek"), []byte("apu"), []byte("apv"),
 			&crypto.PublicKey{})
 
 		require.NotNil(t, key)
@@ -937,7 +953,7 @@ func TestWrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, "", []byte("cek"), []byte("apu"), []byte("apv"),
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, "", []byte("cek"), []byte("apu"), []byte("apv"),
 			&crypto.PublicKey{})
 
 		require.Nil(t, key)
@@ -961,7 +977,7 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
 			&crypto.PublicKey{})
 
 		require.NotNil(t, key)
@@ -975,7 +991,7 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
 			&crypto.PublicKey{})
 
 		require.Nil(t, key)
@@ -994,7 +1010,7 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
 			&crypto.PublicKey{})
 
 		require.Nil(t, key)
@@ -1014,8 +1030,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, "invalid", []byte("cek"), []byte("apu"), []byte("apv"),
-			&crypto.PublicKey{})
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, "invalid", []byte("cek"), []byte("apu"),
+			[]byte("apv"), &crypto.PublicKey{})
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1035,8 +1051,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
-			&crypto.PublicKey{})
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, testKeyID, []byte("cek"), []byte("apu"),
+			[]byte("apv"), &crypto.PublicKey{})
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1056,8 +1072,8 @@ func TestWrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.WrapKey(testKeystoreID, testKeyID, []byte("cek"), []byte("apu"), []byte("apv"),
-			&crypto.PublicKey{})
+		key, err := srv.WrapKey(context.Background(), testKeystoreID, testKeyID, []byte("cek"), []byte("apu"),
+			[]byte("apv"), &crypto.PublicKey{})
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1080,7 +1096,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
 
 		require.NotNil(t, key)
 		require.NoError(t, err)
@@ -1093,7 +1109,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1111,7 +1127,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1130,7 +1146,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, "", &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, "", &crypto.RecipientWrappedKey{}, nil)
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1150,7 +1166,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1170,7 +1186,7 @@ func TestUnwrapKey_Anoncrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, nil)
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1199,7 +1215,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		senderPubKey, err := keyio.ExtractPrimaryPublicKey(senderKH)
 		require.NoError(t, err)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, senderPubKey)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID,
+			&crypto.RecipientWrappedKey{}, senderPubKey)
 
 		require.NotNil(t, key)
 		require.NoError(t, err)
@@ -1217,7 +1234,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		srv := kms.NewService(provider)
 		require.NotNil(t, srv)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, &crypto.PublicKey{})
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID,
+			&crypto.RecipientWrappedKey{}, &crypto.PublicKey{})
 
 		require.Nil(t, key)
 		require.Error(t, err)
@@ -1242,7 +1260,8 @@ func TestUnwrapKey_Authcrypt(t *testing.T) {
 		senderPubKey, err := keyio.ExtractPrimaryPublicKey(senderKH)
 		require.NoError(t, err)
 
-		key, err := srv.UnwrapKey(testKeystoreID, testKeyID, &crypto.RecipientWrappedKey{}, senderPubKey)
+		key, err := srv.UnwrapKey(context.Background(), testKeystoreID, testKeyID,
+			&crypto.RecipientWrappedKey{}, senderPubKey)
 
 		require.Nil(t, key)
 		require.Error(t, err)

--- a/pkg/restapi/kms/operation/middlware_test.go
+++ b/pkg/restapi/kms/operation/middlware_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package operation // nolint:testpackage // mocking internal implementation details
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -276,7 +277,7 @@ type mockAuthService struct {
 	resolveErr       error
 }
 
-func (m *mockAuthService) CreateDIDKey() (string, error) {
+func (m *mockAuthService) CreateDIDKey(context.Context) (string, error) {
 	if m.createDIDKeyFunc != nil {
 		return m.createDIDKeyFunc()
 	}
@@ -284,7 +285,7 @@ func (m *mockAuthService) CreateDIDKey() (string, error) {
 	return "", nil
 }
 
-func (m *mockAuthService) NewCapability(options ...zcapld.CapabilityOption) (*zcapld.Capability, error) {
+func (m *mockAuthService) NewCapability(context.Context, ...zcapld.CapabilityOption) (*zcapld.Capability, error) {
 	return m.newCapabilityVal, m.newCapabilityErr
 }
 

--- a/pkg/restapi/kms/operation/operations_test.go
+++ b/pkg/restapi/kms/operation/operations_test.go
@@ -166,7 +166,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 		srv.CreateKeystoreValue = &keystore.Keystore{ID: testKeystoreID}
 
 		op := operation.New(newConfig(withKeystoreService(srv), withEDV(),
-			withAuthService(&mockAuthService{createDIDKeyFunc: func() (string, error) {
+			withAuthService(&mockAuthService{createDIDKeyFunc: func(context.Context) (string, error) {
 				return "", fmt.Errorf("failed to create did key")
 			}}))) // TODO(#53): Improve reliability
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
@@ -1199,15 +1199,15 @@ func withAuthService(service authService) optionFn {
 }
 
 type authService interface {
-	CreateDIDKey() (string, error)
-	NewCapability(options ...zcapld.CapabilityOption) (*zcapld.Capability, error)
+	CreateDIDKey(context.Context) (string, error)
+	NewCapability(context.Context, ...zcapld.CapabilityOption) (*zcapld.Capability, error)
 	KMS() arieskms.KeyManager
 	Crypto() crypto.Crypto
 	Resolve(string) (*zcapld.Capability, error)
 }
 
 type mockAuthService struct {
-	createDIDKeyFunc func() (string, error)
+	createDIDKeyFunc func(context.Context) (string, error)
 	newCapabilityVal *zcapld.Capability
 	newCapabilityErr error
 	keyManager       arieskms.KeyManager
@@ -1216,15 +1216,15 @@ type mockAuthService struct {
 	resolveErr       error
 }
 
-func (m *mockAuthService) CreateDIDKey() (string, error) {
+func (m *mockAuthService) CreateDIDKey(ctx context.Context) (string, error) {
 	if m.createDIDKeyFunc != nil {
-		return m.createDIDKeyFunc()
+		return m.createDIDKeyFunc(ctx)
 	}
 
 	return "", nil
 }
 
-func (m *mockAuthService) NewCapability(options ...zcapld.CapabilityOption) (*zcapld.Capability, error) {
+func (m *mockAuthService) NewCapability(context.Context, ...zcapld.CapabilityOption) (*zcapld.Capability, error) {
 	return m.newCapabilityVal, m.newCapabilityErr
 }
 

--- a/pkg/storage/edv/edvstorage_test.go
+++ b/pkg/storage/edv/edvstorage_test.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package edv //nolint:testpackage // need to test local methods
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/tink/go/keyset"
@@ -44,7 +46,7 @@ func TestSignHeader(t *testing.T) {
 		c.HeaderSigner = &mockHeaderSigner{
 			signErr: expected,
 		}
-		h, err := c.signHeader(&http.Request{Header: make(map[string][]string)}, []byte("{}"))
+		h, err := c.signHeader(&http.Request{Header: make(map[string][]string), URL: &url.URL{}}, []byte("{}"))
 
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
@@ -62,7 +64,7 @@ func TestSignHeader(t *testing.T) {
 		srv.GetKeyHandleValue = kh
 
 		c := buildConfig(srv)
-		h, err := c.signHeader(&http.Request{Header: make(map[string][]string)}, nil)
+		h, err := c.signHeader(&http.Request{Header: make(map[string][]string), URL: &url.URL{}}, nil)
 
 		require.NoError(t, err)
 		require.Nil(t, h)
@@ -80,7 +82,7 @@ func TestNewProvider(t *testing.T) {
 		}
 		srv.GetKeyHandleValue = kh
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.NotNil(t, p)
 		require.NoError(t, err)
@@ -90,7 +92,7 @@ func TestNewProvider(t *testing.T) {
 		srv := mockkeystore.NewMockService()
 		srv.GetErr = errors.New("get err")
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.Nil(t, p)
 		require.Error(t, err)
@@ -103,7 +105,7 @@ func TestNewProvider(t *testing.T) {
 		}
 		srv.GetKeyHandleErr = errors.New("get key handle error")
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.Nil(t, p)
 		require.Error(t, err)
@@ -123,7 +125,7 @@ func TestNewProvider(t *testing.T) {
 			KeystoreID:      testKeystoreID,
 		}
 
-		p, err := NewStorageProvider(config)
+		p, err := NewStorageProvider(context.Background(), config)
 
 		require.Nil(t, p)
 		require.Error(t, err)
@@ -139,7 +141,7 @@ func TestNewProvider(t *testing.T) {
 		}
 		srv.GetKeyHandleValue = kh
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.Nil(t, p)
 		require.Error(t, err)
@@ -155,7 +157,7 @@ func TestNewProvider(t *testing.T) {
 		}
 		srv.GetKeyHandleValue = kh
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.Nil(t, p)
 		require.Error(t, err)
@@ -172,7 +174,7 @@ func TestNewProvider(t *testing.T) {
 		srv.GetKeyHandleValue = kh
 		srv.KeyManagerErr = errors.New("get key manager error")
 
-		p, err := NewStorageProvider(buildConfig(srv))
+		p, err := NewStorageProvider(context.Background(), buildConfig(srv))
 
 		require.Nil(t, p)
 		require.Error(t, err)

--- a/test/bdd/fixtures/jaeger/docker-compose.yml
+++ b/test/bdd/fixtures/jaeger/docker-compose.yml
@@ -1,0 +1,28 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+  jaeger.example.com:
+    container_name: jaeger.example.com
+    image: jaegertracing/all-in-one:1.21
+    ports:
+      - 5775:5775/udp
+      - 6831:6831/udp
+      - 6832:6832/udp
+      - 5778:5778
+      - 16686:16686
+      - 14268:14268
+      - 14250:14250
+      - 9411:9411
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    networks:
+      - couchdb_bdd_net
+
+networks:
+  couchdb_bdd_net:
+    external: true

--- a/test/bdd/fixtures/kms/docker-compose.yml
+++ b/test/bdd/fixtures/kms/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - KMS_HUB_AUTH_API_TOKEN=test_token
       - KMS_CACHE_EXPIRATION=10m
       - KMS_LOG_LEVEL=debug
+      - KMS_JAEGER_URL=http://jaeger.example.com:14268/api/traces
     ports:
       - 8077:8077
     entrypoint: ""
@@ -66,6 +67,7 @@ services:
       - KMS_CACHE_EXPIRATION=10m
       - KMS_ZCAP_ENABLE=true
       - KMS_LOG_LEVEL=debug
+      - KMS_JAEGER_URL=http://jaeger.example.com:14268/api/traces
     ports:
       - 8076:8076
     entrypoint: ""

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -469,6 +469,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-metrics-stackdriver v0.2.0/go.mod h1:KLcPyp3dWJAFD+yHisGlJSZktIsTjb50eB72U2YZ9K0=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -1050,6 +1052,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/otel v0.15.0 h1:CZFy2lPhxd4HlhZnYK8gRyDotksO3Ip9rBweY1vVYJw=
+go.opentelemetry.io/otel v0.15.0/go.mod h1:e4GKElweB8W2gWUqbghw0B8t5MCTccc9212eNHnOHwA=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=


### PR DESCRIPTION
This PR adds support for [OpenTelemetry](https://opentelemetry.io/) tracing. Trace data are sent to the [Jaegar](https://www.jaegertracing.io/) endpoint. The latter should be run from within `test/bdd/fixtures/jaeger` with `docker-compose up`. Jaeger UI will be available [here](http://jaeger.example.com:16686/search) (update `/etc/hosts` with `127.0.0.1 jaeger.example.com` entry).

Most probably that tracing functionality will be removed before release but for now it should help with investigating performance issues.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>